### PR TITLE
Fix for the windows install script

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -8,14 +8,14 @@ $ErrorActionPreference = 'Stop'
 $repoUrl = 'https://github.com/Xndr2/listening-stats'
 $appName = 'listening-stats'
 
-Write-Host '
+Write-Host @'
  _     _     _             _               ____  _        _       
 | |   (_)___| |_ ___ _ __ (_)_ __   __ _  / ___|| |_ __ _| |_ ___ 
 | |   | / __| __/ _ \ '\''_ \| | '\''_ \ / _` | \___ \| __/ _` | __/ __|
 | |___| \__ \ ||  __/ | | | | | | | (_| |  ___) | || (_| | |_\__ \
 |_____|_|___/\__\___|_| |_|_|_| |_|\__, | |____/ \__\__,_|\__|___/
                                    |___/                          
-' -ForegroundColor 'Green'
+'@ -ForegroundColor 'Green'
 
 Write-Host 'Listening Stats Installer for Windows' -ForegroundColor 'Cyan'
 Write-Host ''


### PR DESCRIPTION
Just a small change I already mention in issue page here https://github.com/Xndr2/listening-stats/issues/1

Only affects the windows install script, add 2 @ signs for the ASCI banner, with that the script can run without any errors.