### PR TITLE
Add streak tracking with CalendarHeatmap for stats.fm provider

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,56 +1,56 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.4.10/schema.json",
-	"assist": { "actions": { "source": { "organizeImports": "on" } } },
-	"linter": {
-		"enabled": true,
-		"rules": {
-			"recommended": true,
-			"suspicious": {
-				"noArrayIndexKey": "off"
-			},
-			"security": {
-				"noDangerouslySetInnerHtml": "off"
-			},
-			"a11y": {
-				"noStaticElementInteractions": "off",
-				"useKeyWithClickEvents": "off",
-				"useAriaPropsSupportedByRole": "off",
-				"useFocusableInteractive": "off",
-				"useSemanticElements": "off"
-			}
-		}
-	},
-	"formatter": {
-		"enabled": true,
-		"indentStyle": "tab",
-		"lineWidth": 100
-	},
-	"javascript": {
-		"formatter": {
-			"quoteStyle": "double",
-			"semicolons": "always"
-		}
-	},
-	"files": {
-		"includes": ["src/**"]
-	},
-	"overrides": [
-		{
-			"includes": ["src/test/**"],
-			"linter": {
-				"rules": {
-					"suspicious": {
-						"noExplicitAny": "off",
-						"useIterableCallbackReturn": "off"
-					},
-					"style": {
-						"noNonNullAssertion": "off"
-					},
-					"correctness": {
-						"noUnsafeOptionalChaining": "off"
-					}
-				}
-			}
-		}
-	]
+  "$schema": "https://biomejs.dev/schemas/2.4.10/schema.json",
+  "assist": { "actions": { "source": { "organizeImports": "on" } } },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true,
+      "suspicious": {
+        "noArrayIndexKey": "off"
+      },
+      "security": {
+        "noDangerouslySetInnerHtml": "off"
+      },
+      "a11y": {
+        "noStaticElementInteractions": "off",
+        "useKeyWithClickEvents": "off",
+        "useAriaPropsSupportedByRole": "off",
+        "useFocusableInteractive": "off",
+        "useSemanticElements": "off"
+      }
+    }
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "tab",
+    "lineWidth": 120
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "double",
+      "semicolons": "always"
+    }
+  },
+  "files": {
+    "includes": ["src/**"]
+  },
+  "overrides": [
+    {
+      "includes": ["src/test/**"],
+      "linter": {
+        "rules": {
+          "suspicious": {
+            "noExplicitAny": "off",
+            "useIterableCallbackReturn": "off"
+          },
+          "style": {
+            "noNonNullAssertion": "off"
+          },
+          "correctness": {
+            "noUnsafeOptionalChaining": "off"
+          }
+        }
+      }
+    }
+  ]
 }

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -302,6 +302,7 @@ function App() {
 	const availableSectionIds = new Set(getSectionsForProvider(activeCaps).map((s) => s.id));
 
 	const prefs = getPreferences();
+	const showStreak = capabilities?.hasStreakData || activeProviderId === "statsfm";
 	void prefsVersion;
 	const isHidden = (id: string) => prefs.hiddenSections.includes(id);
 
@@ -444,7 +445,7 @@ function App() {
 						peakWeekday={stats.peakWeekday ?? 0}
 						dailyPlayCounts={stats.dailyPlayCounts}
 						streak={stats.streak}
-						showStreak={capabilities.hasStreakData}
+							showStreak={showStreak}
 					/>
 				);
 			}
@@ -466,6 +467,7 @@ function App() {
 						totalDuration={stats.totalDuration}
 						listeningDays={stats.listeningDays}
 						dailyPlayCounts={stats.dailyPlayCounts}
+						streak={stats.streak}
 						activePeriod={activePeriod}
 						activeProviderId={activeProviderId}
 					/>

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -8,13 +8,7 @@ import type { AppError } from "../shared/errors";
 import { classifyStatsFmError, StatsFmError } from "../shared/errors";
 import { initProviders } from "../shared/stats/init-providers";
 import { LOCAL_PERIODS, WORLD_TAB_PERIOD, WORLD_TAB_PERIOD_ID } from "../shared/stats/periods";
-import {
-	allLoading,
-	allResolved,
-	EMPTY_STATS,
-	type SectionSlots,
-	slotKeyForWave,
-} from "../shared/stats/progressive";
+import { allLoading, allResolved, EMPTY_STATS, type SectionSlots, slotKeyForWave } from "../shared/stats/progressive";
 import type { ProviderRegistry } from "../shared/stats/provider";
 import { providerRegistry } from "../shared/stats/provider";
 import {
@@ -103,9 +97,7 @@ function App() {
 	const [tourActive, setTourActive] = useState(() => shouldAutoStartTour(__VERSION__));
 	const [activePage, setActivePage] = useState<string>(() => getPreferences().activePage);
 	const [showShare, setShowShare] = useState(false);
-	const [remoteAnnouncement, setRemoteAnnouncement] = useState<ParsedRemoteAnnouncement | null>(
-		null,
-	);
+	const [remoteAnnouncement, setRemoteAnnouncement] = useState<ParsedRemoteAnnouncement | null>(null);
 	const [updateCheck, setUpdateCheck] = useState<UpdateCheckResult | null>(null);
 	const [showUpdateModal, setShowUpdateModal] = useState(false);
 	// silent=true skips loading skeleton (used for background refresh)
@@ -135,33 +127,30 @@ function App() {
 
 			if (provider.calculateStatsProgressive) {
 				let hasWaveError = false;
-				const result = await provider.calculateStatsProgressive(
-					period,
-					(partial, wave, waveError) => {
-						if (gen !== generationRef.current) return;
-						const slotKey = slotKeyForWave(wave);
-						if ("topTracks" in partial) {
-							setListColumnLoading((prev) => ({ ...prev, tracks: false }));
-						}
-						if ("topArtists" in partial) {
-							setListColumnLoading((prev) => ({ ...prev, artists: false }));
-						}
-						if ("topAlbums" in partial) {
-							setListColumnLoading((prev) => ({ ...prev, albums: false }));
-						}
-						if ("dailyPlayCounts" in partial || "listeningDays" in partial) {
-							setSectionSlots((prev) => ({ ...prev, consistency: "resolved" }));
-						}
-						if (waveError) {
-							hasWaveError = true;
-							setSectionErrors((prev) => ({ ...prev, [slotKey]: waveError }));
-							setSectionSlots((prev) => ({ ...prev, [slotKey]: "error" }));
-						} else {
-							setStats((prev) => (prev ? { ...prev, ...partial } : { ...EMPTY_STATS, ...partial }));
-							setSectionSlots((prev) => ({ ...prev, [slotKey]: "resolved" }));
-						}
-					},
-				);
+				const result = await provider.calculateStatsProgressive(period, (partial, wave, waveError) => {
+					if (gen !== generationRef.current) return;
+					const slotKey = slotKeyForWave(wave);
+					if ("topTracks" in partial) {
+						setListColumnLoading((prev) => ({ ...prev, tracks: false }));
+					}
+					if ("topArtists" in partial) {
+						setListColumnLoading((prev) => ({ ...prev, artists: false }));
+					}
+					if ("topAlbums" in partial) {
+						setListColumnLoading((prev) => ({ ...prev, albums: false }));
+					}
+					if ("dailyPlayCounts" in partial || "listeningDays" in partial) {
+						setSectionSlots((prev) => ({ ...prev, consistency: "resolved" }));
+					}
+					if (waveError) {
+						hasWaveError = true;
+						setSectionErrors((prev) => ({ ...prev, [slotKey]: waveError }));
+						setSectionSlots((prev) => ({ ...prev, [slotKey]: "error" }));
+					} else {
+						setStats((prev) => (prev ? { ...prev, ...partial } : { ...EMPTY_STATS, ...partial }));
+						setSectionSlots((prev) => ({ ...prev, [slotKey]: "resolved" }));
+					}
+				});
 				if (gen !== generationRef.current) return;
 				// Always apply the terminal result to avoid stale/missing section holes.
 				setStats((prev) => ({ ...(prev ?? EMPTY_STATS), ...result }));
@@ -209,10 +198,7 @@ function App() {
 		initProviders().then(() => {
 			const providerPeriods = getProviderPeriods();
 			setPeriods(providerPeriods);
-			const restored = restorePeriodForProvider(
-				providerRegistry.getActiveId() ?? "local",
-				providerPeriods,
-			);
+			const restored = restorePeriodForProvider(providerRegistry.getActiveId() ?? "local", providerPeriods);
 			setActivePeriod(restored);
 			setInitialized(true);
 		});
@@ -331,9 +317,7 @@ function App() {
 		setPreference("activePage", "dashboard");
 		setActivePeriod(period);
 		savePeriodForProvider(providerRegistry.getActiveId() ?? "local", period.id);
-		window.dispatchEvent(
-			new CustomEvent(EVENTS.DASHBOARD_PERIOD_CHANGED, { detail: { periodId: period.id } }),
-		);
+		window.dispatchEvent(new CustomEvent(EVENTS.DASHBOARD_PERIOD_CHANGED, { detail: { periodId: period.id } }));
 	}, []);
 
 	const handleRefresh = useCallback(async () => {
@@ -366,8 +350,7 @@ function App() {
 	const renderSectionById = (id: string): React.ReactNode => {
 		switch (id) {
 			case "overview":
-				if (isSlotLoading("overview"))
-					return <OverviewSection loading activePeriod={activePeriod} />;
+				if (isSlotLoading("overview")) return <OverviewSection loading activePeriod={activePeriod} />;
 				if (sectionErrors.overview)
 					return (
 						<InlineErrorCard
@@ -382,13 +365,7 @@ function App() {
 				if (isSlotLoading("lists") || !stats) return null;
 				if (!capabilities?.hasGenreData) return null;
 				if (stats.topGenres.length === 0) return null;
-				return (
-					<TopGenres
-						topGenres={stats.topGenres}
-						onGenreClick={setActiveGenre}
-						activeGenre={prefs.activeGenre}
-					/>
-				);
+				return <TopGenres topGenres={stats.topGenres} onGenreClick={setActiveGenre} activeGenre={prefs.activeGenre} />;
 			case "top-lists": {
 				const listsLoading = isSlotLoading("lists");
 				if (sectionErrors.lists)
@@ -445,7 +422,7 @@ function App() {
 						peakWeekday={stats.peakWeekday ?? 0}
 						dailyPlayCounts={stats.dailyPlayCounts}
 						streak={stats.streak}
-							showStreak={showStreak}
+						showStreak={showStreak}
 					/>
 				);
 			}
@@ -498,9 +475,7 @@ function App() {
 		}
 
 		const sectionOrder = prefs.sectionOrder;
-		const visibleSections = sectionOrder.filter(
-			(id) => availableSectionIds.has(id) && !isHidden(id),
-		);
+		const visibleSections = sectionOrder.filter((id) => availableSectionIds.has(id) && !isHidden(id));
 		const loadingSections = (
 			Object.entries(sectionSlots) as Array<[keyof SectionSlots, SectionSlots[keyof SectionSlots]]>
 		)
@@ -593,9 +568,7 @@ function App() {
 							titleOnly={activeBanner.actionOpensChangelog === true}
 							actionLabel={activeBanner.actionLabel}
 							actionUrl={activeBanner.actionUrl}
-							onActionClick={
-								activeBanner.actionOpensChangelog ? () => void openUpdatesModal() : undefined
-							}
+							onActionClick={activeBanner.actionOpensChangelog ? () => void openUpdatesModal() : undefined}
 							onDismiss={handleDismissBanner}
 						/>
 					)}

--- a/src/app/capabilities.ts
+++ b/src/app/capabilities.ts
@@ -30,12 +30,7 @@ const LOCAL_TILES: readonly string[] = [
 	"est-payout",
 ];
 
-const STATSFM_TILES: readonly string[] = [
-	"unique-artists",
-	"new-artists",
-	"top-genre",
-	"est-payout",
-];
+const STATSFM_TILES: readonly string[] = ["unique-artists", "new-artists", "top-genre", "est-payout"];
 
 const TILE_LABELS: Record<string, string> = {
 	tracks: "Tracks",
@@ -63,10 +58,7 @@ function isTileAvailable(tileId: string, caps: ProviderCapabilities): boolean {
 	return true;
 }
 
-export function getOverviewTilesForProvider(
-	providerId: string,
-	caps: ProviderCapabilities,
-): TileConfig[] {
+export function getOverviewTilesForProvider(providerId: string, caps: ProviderCapabilities): TileConfig[] {
 	const tileIds = providerId === "local" ? LOCAL_TILES : STATSFM_TILES;
 	return tileIds.map((id) => ({
 		id,

--- a/src/app/components/ActivityChart.tsx
+++ b/src/app/components/ActivityChart.tsx
@@ -36,10 +36,7 @@ export function ActivityChart({ hourlyDistribution, peakHour }: ActivityChartPro
 							label={`${formatHour(hr, prefs.use24HourTime)}: ${val} plays`}
 							placement="top"
 						>
-							<div
-								className={`activity-bar${isPeak ? " peak" : ""}`}
-								style={{ height: `${heightPct}%` }}
-							/>
+							<div className={`activity-bar${isPeak ? " peak" : ""}`} style={{ height: `${heightPct}%` }} />
 						</Spicetify.ReactComponent.TooltipWrapper>
 					);
 				})}

--- a/src/app/components/ActivitySection.tsx
+++ b/src/app/components/ActivitySection.tsx
@@ -21,8 +21,8 @@ const WEEKDAYS_FULL = [
 
 const TAB_OPTIONS: { value: ActivityTabId; label: string }[] = [
 	{ value: "hour", label: "By hour" },
-	{ value: "weekday", label: "By weekday" },
-	{ value: "day", label: "By day" },
+	{ value: "weekday", label: "By week" },
+	{ value: "day", label: "By month" },
 ];
 
 interface ActivitySectionProps {

--- a/src/app/components/ActivitySection.tsx
+++ b/src/app/components/ActivitySection.tsx
@@ -9,15 +9,7 @@ const { useState } = Spicetify.React;
 const HOURS = Array.from({ length: 24 }, (_, i) => i);
 const DAYS = Array.from({ length: 7 }, (_, i) => i);
 const WEEKDAYS_ABBR = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
-const WEEKDAYS_FULL = [
-	"Monday",
-	"Tuesday",
-	"Wednesday",
-	"Thursday",
-	"Friday",
-	"Saturday",
-	"Sunday",
-];
+const WEEKDAYS_FULL = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"];
 
 const TAB_OPTIONS: { value: ActivityTabId; label: string }[] = [
 	{ value: "hour", label: "By hour" },
@@ -109,8 +101,7 @@ export function ActivitySection({
 					<CalendarHeatmap dailyPlayCounts={dailyPlayCounts ?? []} />
 					{showStreak && streak != null && streak > 0 && (
 						<div className="streak-callout">
-							You've listened on <strong>{streak} days</strong> in a row &middot; longest stretch
-							this year.
+							You've listened on <strong>{streak} days</strong> in a row &middot; longest stretch this year.
 						</div>
 					)}
 				</>
@@ -134,10 +125,7 @@ function renderHourlyChart(hourlyDistribution: number[], peakHour: number, use24
 							label={`${formatHour(hr, use24h)}: ${val} plays`}
 							placement="top"
 						>
-							<div
-								className={`activity-bar${isPeak ? " peak" : ""}`}
-								style={{ height: `${heightPct}%` }}
-							/>
+							<div className={`activity-bar${isPeak ? " peak" : ""}`} style={{ height: `${heightPct}%` }} />
 						</Spicetify.ReactComponent.TooltipWrapper>
 					);
 				})}
@@ -164,14 +152,8 @@ function renderWeekdayChart(weekdayDistribution: number[], peakWeekday: number) 
 				return (
 					<div key={day} className="weekday-column">
 						<div className="weekday-bar-area">
-							<Spicetify.ReactComponent.TooltipWrapper
-								label={`${WEEKDAYS_FULL[day]}: ${val} plays`}
-								placement="top"
-							>
-								<div
-									className={`activity-bar${isPeak ? " peak" : ""}`}
-									style={{ height: `${heightPct}%` }}
-								/>
+							<Spicetify.ReactComponent.TooltipWrapper label={`${WEEKDAYS_FULL[day]}: ${val} plays`} placement="top">
+								<div className={`activity-bar${isPeak ? " peak" : ""}`} style={{ height: `${heightPct}%` }} />
 							</Spicetify.ReactComponent.TooltipWrapper>
 						</div>
 						<span className="weekday-label">{WEEKDAYS_ABBR[day]}</span>

--- a/src/app/components/AnnouncementBanner.tsx
+++ b/src/app/components/AnnouncementBanner.tsx
@@ -66,12 +66,7 @@ export function AnnouncementBanner({
 						{actionLabel}
 					</a>
 				))}
-			<button
-				type="button"
-				className="announcement-banner-dismiss"
-				onClick={onDismiss}
-				aria-label="Dismiss"
-			>
+			<button type="button" className="announcement-banner-dismiss" onClick={onDismiss} aria-label="Dismiss">
 				×
 			</button>
 		</div>

--- a/src/app/components/AppFooter.tsx
+++ b/src/app/components/AppFooter.tsx
@@ -1,9 +1,6 @@
 const { memo } = Spicetify.React;
 
-import {
-	COMMUNITY_BUYMEACOFFEE_URL,
-	COMMUNITY_DISCORD_URL,
-} from "../../shared/constants/community-links";
+import { COMMUNITY_BUYMEACOFFEE_URL, COMMUNITY_DISCORD_URL } from "../../shared/constants/community-links";
 
 interface AppFooterProps {
 	version: string;
@@ -15,12 +12,7 @@ function AppFooterInner({ version, onCheckForUpdates }: AppFooterProps) {
 		<footer className="stats-app-footer">
 			<span className="stats-app-footer-credit">Made with love by Xndr</span>
 			<span className="stats-app-footer-links" aria-label="Community links">
-				<a
-					className="stats-app-footer-link"
-					href={COMMUNITY_DISCORD_URL}
-					target="_blank"
-					rel="noopener noreferrer"
-				>
+				<a className="stats-app-footer-link" href={COMMUNITY_DISCORD_URL} target="_blank" rel="noopener noreferrer">
 					Discord
 				</a>
 				<a

--- a/src/app/components/CalendarHeatmap.tsx
+++ b/src/app/components/CalendarHeatmap.tsx
@@ -126,10 +126,7 @@ export function CalendarHeatmap({ dailyPlayCounts }: CalendarHeatmapProps) {
 						key={t}
 						className="heatmap-legend-swatch"
 						style={{
-							background:
-								t === 0.05
-									? "rgba(var(--spice-rgb-misc), 0.05)"
-									: `rgba(var(--spice-rgb-button), ${t})`,
+							background: t === 0.05 ? "rgba(var(--spice-rgb-misc), 0.05)" : `rgba(var(--spice-rgb-button), ${t})`,
 						}}
 					/>
 				))}

--- a/src/app/components/ConsistencySection.tsx
+++ b/src/app/components/ConsistencySection.tsx
@@ -12,6 +12,7 @@ interface ConsistencySectionProps {
 	totalDuration: number;
 	listeningDays?: number;
 	dailyPlayCounts?: DailyPoint[];
+	streak?: number;
 	activePeriod: Period;
 	activeProviderId?: string;
 }
@@ -21,6 +22,7 @@ interface MetricCardProps {
 	value: string | number;
 	sub: string;
 	tooltip: string;
+	accent?: boolean;
 }
 
 function ymd(ts: number): string {
@@ -72,6 +74,7 @@ export function ConsistencySection({
 	totalDuration,
 	listeningDays,
 	dailyPlayCounts,
+	streak,
 	activePeriod,
 	activeProviderId = "statsfm",
 }: ConsistencySectionProps) {
@@ -108,9 +111,9 @@ export function ConsistencySection({
 	const isLocalProvider = activeProviderId === "local";
 	const Tooltip = Spicetify.ReactComponent.TooltipWrapper;
 
-	const MetricCard = ({ label, value, sub, tooltip }: MetricCardProps) => (
+	const MetricCard = ({ label, value, sub, tooltip, accent }: MetricCardProps) => (
 		<Tooltip label={tooltip}>
-			<div className="consistency-metric">
+			<div className={`consistency-metric${accent ? " consistency-metric--accent" : ""}`}>
 				<div className="consistency-metric-label">{label}</div>
 				<div className="consistency-metric-value">{value}</div>
 				<div className="consistency-metric-sub">{sub}</div>
@@ -144,10 +147,11 @@ export function ConsistencySection({
 					tooltip="Average listening duration in minutes across active days."
 				/>
 				<MetricCard
-					label="Longest gap"
-					value={longestGap}
-					sub="days without plays"
-					tooltip="Longest consecutive run of days in this period without any streams."
+					label="Current streak"
+					value={streak != null && streak > 0 ? `${streak}d` : "-"}
+					sub="consecutive days"
+					tooltip="Consecutive calendar days with at least one play (local timezone)."
+					accent={streak != null && streak > 0}
 				/>
 			</div>
 			{!isTodayPeriod && (

--- a/src/app/components/ConsistencySection.tsx
+++ b/src/app/components/ConsistencySection.tsx
@@ -2,235 +2,260 @@ import type { Period } from "../../shared/types/stats";
 import { SkeletonBlock, SkeletonTextLine } from "./SkeletonPrimitives";
 
 interface DailyPoint {
-	date: string;
-	count: number;
+  date: string;
+  count: number;
 }
 
 interface ConsistencySectionProps {
-	loading?: boolean;
-	totalPlays: number;
-	totalDuration: number;
-	listeningDays?: number;
-	dailyPlayCounts?: DailyPoint[];
-	streak?: number;
-	activePeriod: Period;
-	activeProviderId?: string;
+  loading?: boolean;
+  totalPlays: number;
+  totalDuration: number;
+  listeningDays?: number;
+  dailyPlayCounts?: DailyPoint[];
+  streak?: number;
+  activePeriod: Period;
+  activeProviderId?: string;
 }
 
 interface MetricCardProps {
-	label: string;
-	value: string | number;
-	sub: string;
-	tooltip: string;
-	accent?: boolean;
+  label: string;
+  value: string | number;
+  sub: string;
+  tooltip: string;
+  accent?: boolean;
 }
 
 function ymd(ts: number): string {
-	return new Date(ts).toISOString().slice(0, 10);
+  return new Date(ts).toISOString().slice(0, 10);
 }
 
 function buildWindow(points: DailyPoint[], period: Period): DailyPoint[] {
-	const { start, end } = period.getBoundaries();
-	if (end === Number.MAX_SAFE_INTEGER) {
-		return points.slice(-30);
-	}
-	const endDayTs = end - 1;
-	const startDay = ymd(start);
-	const endDay = ymd(endDayTs);
-	return points.filter((p) => p.date >= startDay && p.date <= endDay);
+  const { start, end } = period.getBoundaries();
+  if (end === Number.MAX_SAFE_INTEGER) {
+    return points.slice(-30);
+  }
+  const endDayTs = end - 1;
+  const startDay = ymd(start);
+  const endDay = ymd(endDayTs);
+  return points.filter((p) => p.date >= startDay && p.date <= endDay);
 }
 
 function computeLongestGap(points: DailyPoint[]): number {
-	let longest = 0;
-	let current = 0;
-	for (const p of points) {
-		if (p.count > 0) {
-			current = 0;
-			continue;
-		}
-		current += 1;
-		longest = Math.max(longest, current);
-	}
-	return longest;
+  let longest = 0;
+  let current = 0;
+  for (const p of points) {
+    if (p.count > 0) {
+      current = 0;
+      continue;
+    }
+    current += 1;
+    longest = Math.max(longest, current);
+  }
+  return longest;
 }
 
 function formatDayLabel(date: string): string {
-	let ts = new Date(date);
-	if (!Number.isFinite(ts.getTime())) {
-		const dayOnly = date.slice(0, 10);
-		ts = new Date(`${dayOnly}T00:00:00`);
-	}
-	if (!Number.isFinite(ts.getTime())) return date.slice(0, 10);
-	return ts.toLocaleDateString(undefined, {
-		weekday: "short",
-		month: "short",
-		day: "numeric",
-	});
+  let ts = new Date(date);
+  if (!Number.isFinite(ts.getTime())) {
+    const dayOnly = date.slice(0, 10);
+    ts = new Date(`${dayOnly}T00:00:00`);
+  }
+  if (!Number.isFinite(ts.getTime())) return date.slice(0, 10);
+  return ts.toLocaleDateString(undefined, {
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+  });
 }
 
 export function ConsistencySection({
-	loading = false,
-	totalPlays,
-	totalDuration,
-	listeningDays,
-	dailyPlayCounts,
-	streak,
-	activePeriod,
-	activeProviderId = "statsfm",
+  loading = false,
+  totalPlays,
+  totalDuration,
+  listeningDays,
+  dailyPlayCounts,
+  streak,
+  activePeriod,
+  activeProviderId = "statsfm",
 }: ConsistencySectionProps) {
-	if (loading) {
-		return (
-			<div className="section-card consistency-section" aria-hidden="true">
-				<header className="section-heading">
-					<span className="section-kicker">Patterns</span>
-					<h2 className="section-title">Consistency</h2>
-				</header>
-				<div className="consistency-grid">
-					{Array.from({ length: 4 }).map((_, i) => (
-						<div key={i} className="consistency-metric">
-							<SkeletonTextLine width="55%" />
-							<SkeletonBlock width="45%" height={24} style={{ marginTop: 8 }} />
-							<SkeletonTextLine width="70%" />
-						</div>
-					))}
-				</div>
-			</div>
-		);
-	}
-	const points = buildWindow(dailyPlayCounts ?? [], activePeriod);
-	const totalDays = points.length;
-	const activeDays =
-		points.length > 0 ? points.filter((p) => p.count > 0).length : (listeningDays ?? 0);
-	const avgPlaysPerActiveDay = activeDays > 0 ? totalPlays / activeDays : 0;
-	const avgMinutesPerActiveDay = activeDays > 0 ? totalDuration / 60000 / activeDays : 0;
-	const longestGap = computeLongestGap(points);
-	const coveragePct = totalDays > 0 ? Math.round((activeDays / totalDays) * 100) : 0;
-	const trend = points.slice(-14);
-	const trendMax = Math.max(...trend.map((p) => p.count), 1);
-	const isTodayPeriod = activePeriod.id === "today" || activePeriod.id === "sfm-today";
-	const isLocalProvider = activeProviderId === "local";
-	const Tooltip = Spicetify.ReactComponent.TooltipWrapper;
+  if (loading) {
+    return (
+      <div className="section-card consistency-section" aria-hidden="true">
+        <header className="section-heading">
+          <span className="section-kicker">Patterns</span>
+          <h2 className="section-title">Consistency</h2>
+        </header>
+        <div className="consistency-grid">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <div key={i} className="consistency-metric">
+              <SkeletonTextLine width="55%" />
+              <SkeletonBlock width="45%" height={24} style={{ marginTop: 8 }} />
+              <SkeletonTextLine width="70%" />
+            </div>
+          ))}
+        </div>
+      </div>
+    );
+  }
+  const points = buildWindow(dailyPlayCounts ?? [], activePeriod);
+  const totalDays = points.length;
+  const activeDays =
+    points.length > 0
+      ? points.filter((p) => p.count > 0).length
+      : (listeningDays ?? 0);
+  const avgPlaysPerActiveDay = activeDays > 0 ? totalPlays / activeDays : 0;
+  const avgMinutesPerActiveDay =
+    activeDays > 0 ? totalDuration / 60000 / activeDays : 0;
+  const longestGap = computeLongestGap(points);
+  const coveragePct =
+    totalDays > 0 ? Math.round((activeDays / totalDays) * 100) : 0;
+  const trend = points.slice(-14);
+  const trendMax = Math.max(...trend.map((p) => p.count), 1);
+  const isTodayPeriod =
+    activePeriod.id === "today" || activePeriod.id === "sfm-today";
+  const isLocalProvider = activeProviderId === "local";
+  const Tooltip = Spicetify.ReactComponent.TooltipWrapper;
 
-	const MetricCard = ({ label, value, sub, tooltip, accent }: MetricCardProps) => (
-		<Tooltip label={tooltip}>
-			<div className={`consistency-metric${accent ? " consistency-metric--accent" : ""}`}>
-				<div className="consistency-metric-label">{label}</div>
-				<div className="consistency-metric-value">{value}</div>
-				<div className="consistency-metric-sub">{sub}</div>
-			</div>
-		</Tooltip>
-	);
+  const MetricCard = ({
+    label,
+    value,
+    sub,
+    tooltip,
+    accent,
+  }: MetricCardProps) => (
+    <Tooltip label={tooltip}>
+      <div
+        className={`consistency-metric${accent ? " consistency-metric--accent" : ""}`}
+      >
+        <div className="consistency-metric-label">{label}</div>
+        <div className="consistency-metric-value">{value}</div>
+        <div className="consistency-metric-sub">{sub}</div>
+      </div>
+    </Tooltip>
+  );
 
-	return (
-		<div className="section-card consistency-section">
-			<header className="section-heading">
-				<span className="section-kicker">Patterns</span>
-				<h2 className="section-title">Consistency</h2>
-			</header>
-			<div className="consistency-grid">
-				<MetricCard
-					label="Listening days"
-					value={activeDays}
-					sub={`out of ${totalDays || activeDays} days`}
-					tooltip="Number of days in this period with at least one stream."
-				/>
-				<MetricCard
-					label="Avg plays / active day"
-					value={Math.round(avgPlaysPerActiveDay)}
-					sub="streams when active"
-					tooltip="Average stream count only across days where you listened."
-				/>
-				<MetricCard
-					label="Avg minutes / active day"
-					value={Math.round(avgMinutesPerActiveDay)}
-					sub="listening time"
-					tooltip="Average listening duration in minutes across active days."
-				/>
-				<MetricCard
-					label="Current streak"
-					value={streak != null && streak > 0 ? `${streak}d` : "-"}
-					sub="consecutive days"
-					tooltip="Consecutive calendar days with at least one play (local timezone)."
-					accent={streak != null && streak > 0}
-				/>
-			</div>
-			{!isTodayPeriod && (
-				<div className="consistency-footer">
-					<Tooltip
-						label={`You listened on ${activeDays} of ${totalDays || activeDays} days in this period.`}
-					>
-						<div className="consistency-coverage">
-							<div className="consistency-coverage-label">Active-day coverage</div>
-							<div className="consistency-coverage-row">
-								<div className="consistency-coverage-track">
-									<div className="consistency-coverage-fill" style={{ width: `${coveragePct}%` }} />
-								</div>
-								<span>{coveragePct}%</span>
-							</div>
-						</div>
-					</Tooltip>
+  return (
+    <div className="section-card consistency-section">
+      <header className="section-heading">
+        <span className="section-kicker">Patterns</span>
+        <h2 className="section-title">Consistency</h2>
+      </header>
+      <div className="consistency-grid">
+        <MetricCard
+          label="Listening days"
+          value={activeDays}
+          sub={`out of ${totalDays || activeDays} days`}
+          tooltip="Number of days in this period with at least one stream."
+        />
+        <MetricCard
+          label="Avg plays / active day"
+          value={Math.round(avgPlaysPerActiveDay)}
+          sub="streams when active"
+          tooltip="Average stream count only across days where you listened."
+        />
+        <MetricCard
+          label="Avg minutes / active day"
+          value={Math.round(avgMinutesPerActiveDay)}
+          sub="listening time"
+          tooltip="Average listening duration in minutes across active days."
+        />
+        <MetricCard
+          label="Current streak"
+          value={streak != null && streak > 0 ? `${streak}d` : "-"}
+          sub="consecutive days"
+          tooltip="Consecutive calendar days with at least one play (local timezone)."
+        />
+      </div>
+      {!isTodayPeriod && (
+        <div className="consistency-footer">
+          <Tooltip
+            label={`You listened on ${activeDays} of ${totalDays || activeDays} days in this period.`}
+          >
+            <div className="consistency-coverage">
+              <div className="consistency-coverage-label">
+                Active-day coverage
+              </div>
+              <div className="consistency-coverage-row">
+                <div className="consistency-coverage-track">
+                  <div
+                    className="consistency-coverage-fill"
+                    style={{ width: `${coveragePct}%` }}
+                  />
+                </div>
+                <span>{coveragePct}%</span>
+              </div>
+            </div>
+          </Tooltip>
 
-					{isLocalProvider ? (
-						<div className="consistency-week-split">
-							<div className="consistency-coverage-label">Weekday vs weekend</div>
-							{(() => {
-								const activePoints = points.filter((p) => p.count > 0);
-								const weekdayActive = activePoints.filter((p) => {
-									const day = new Date(`${p.date}T00:00:00`).getDay();
-									return day >= 1 && day <= 5;
-								}).length;
-								const weekendActive = activePoints.length - weekdayActive;
-								const totalActive = Math.max(weekdayActive + weekendActive, 1);
-								const weekdayPct = Math.round((weekdayActive / totalActive) * 100);
-								const weekendPct = 100 - weekdayPct;
-								return (
-									<div className="consistency-week-split-row">
-										<Tooltip label={`${weekdayActive} active weekdays (${weekdayPct}%)`}>
-											<div className="consistency-week-chip">
-												<span>Weekdays</span>
-												<strong>{weekdayPct}%</strong>
-											</div>
-										</Tooltip>
-										<Tooltip label={`${weekendActive} active weekend days (${weekendPct}%)`}>
-											<div className="consistency-week-chip">
-												<span>Weekend</span>
-												<strong>{weekendPct}%</strong>
-											</div>
-										</Tooltip>
-									</div>
-								);
-							})()}
-						</div>
-					) : (
-						trend.length > 0 && (
-							<div className="consistency-sparkline">
-								<div className="consistency-coverage-label">Last 14 days</div>
-								<div className="consistency-sparkline-bars">
-									{trend.map((p) => {
-										const isPeak = p.count > 0 && p.count === trendMax;
-										return (
-											<Tooltip
-												key={p.date}
-												label={`${formatDayLabel(p.date)}: ${p.count} plays`}
-												placement="top"
-											>
-												<div className="consistency-sparkline-bar-wrap">
-													<div
-														className={`consistency-sparkline-bar${isPeak ? " peak" : ""}`}
-														style={{
-															height: `${Math.max((p.count / trendMax) * 100, p.count > 0 ? 8 : 2)}%`,
-														}}
-													/>
-												</div>
-											</Tooltip>
-										);
-									})}
-								</div>
-							</div>
-						)
-					)}
-				</div>
-			)}
-		</div>
-	);
+          {isLocalProvider ? (
+            <div className="consistency-week-split">
+              <div className="consistency-coverage-label">
+                Weekday vs weekend
+              </div>
+              {(() => {
+                const activePoints = points.filter((p) => p.count > 0);
+                const weekdayActive = activePoints.filter((p) => {
+                  const day = new Date(`${p.date}T00:00:00`).getDay();
+                  return day >= 1 && day <= 5;
+                }).length;
+                const weekendActive = activePoints.length - weekdayActive;
+                const totalActive = Math.max(weekdayActive + weekendActive, 1);
+                const weekdayPct = Math.round(
+                  (weekdayActive / totalActive) * 100,
+                );
+                const weekendPct = 100 - weekdayPct;
+                return (
+                  <div className="consistency-week-split-row">
+                    <Tooltip
+                      label={`${weekdayActive} active weekdays (${weekdayPct}%)`}
+                    >
+                      <div className="consistency-week-chip">
+                        <span>Weekdays</span>
+                        <strong>{weekdayPct}%</strong>
+                      </div>
+                    </Tooltip>
+                    <Tooltip
+                      label={`${weekendActive} active weekend days (${weekendPct}%)`}
+                    >
+                      <div className="consistency-week-chip">
+                        <span>Weekend</span>
+                        <strong>{weekendPct}%</strong>
+                      </div>
+                    </Tooltip>
+                  </div>
+                );
+              })()}
+            </div>
+          ) : (
+            trend.length > 0 && (
+              <div className="consistency-sparkline">
+                <div className="consistency-coverage-label">Last 14 days</div>
+                <div className="consistency-sparkline-bars">
+                  {trend.map((p) => {
+                    const isPeak = p.count > 0 && p.count === trendMax;
+                    return (
+                      <Tooltip
+                        key={p.date}
+                        label={`${formatDayLabel(p.date)}: ${p.count} plays`}
+                        placement="top"
+                      >
+                        <div className="consistency-sparkline-bar-wrap">
+                          <div
+                            className={`consistency-sparkline-bar${isPeak ? " peak" : ""}`}
+                            style={{
+                              height: `${Math.max((p.count / trendMax) * 100, p.count > 0 ? 8 : 2)}%`,
+                            }}
+                          />
+                        </div>
+                      </Tooltip>
+                    );
+                  })}
+                </div>
+              </div>
+            )
+          )}
+        </div>
+      )}
+    </div>
+  );
 }

--- a/src/app/components/ConsistencySection.tsx
+++ b/src/app/components/ConsistencySection.tsx
@@ -2,260 +2,227 @@ import type { Period } from "../../shared/types/stats";
 import { SkeletonBlock, SkeletonTextLine } from "./SkeletonPrimitives";
 
 interface DailyPoint {
-  date: string;
-  count: number;
+	date: string;
+	count: number;
 }
 
 interface ConsistencySectionProps {
-  loading?: boolean;
-  totalPlays: number;
-  totalDuration: number;
-  listeningDays?: number;
-  dailyPlayCounts?: DailyPoint[];
-  streak?: number;
-  activePeriod: Period;
-  activeProviderId?: string;
+	loading?: boolean;
+	totalPlays: number;
+	totalDuration: number;
+	listeningDays?: number;
+	dailyPlayCounts?: DailyPoint[];
+	streak?: number;
+	activePeriod: Period;
+	activeProviderId?: string;
 }
 
 interface MetricCardProps {
-  label: string;
-  value: string | number;
-  sub: string;
-  tooltip: string;
-  accent?: boolean;
+	label: string;
+	value: string | number;
+	sub: string;
+	tooltip: string;
+	accent?: boolean;
 }
 
 function ymd(ts: number): string {
-  return new Date(ts).toISOString().slice(0, 10);
+	return new Date(ts).toISOString().slice(0, 10);
 }
 
 function buildWindow(points: DailyPoint[], period: Period): DailyPoint[] {
-  const { start, end } = period.getBoundaries();
-  if (end === Number.MAX_SAFE_INTEGER) {
-    return points.slice(-30);
-  }
-  const endDayTs = end - 1;
-  const startDay = ymd(start);
-  const endDay = ymd(endDayTs);
-  return points.filter((p) => p.date >= startDay && p.date <= endDay);
+	const { start, end } = period.getBoundaries();
+	if (end === Number.MAX_SAFE_INTEGER) {
+		return points.slice(-30);
+	}
+	const endDayTs = end - 1;
+	const startDay = ymd(start);
+	const endDay = ymd(endDayTs);
+	return points.filter((p) => p.date >= startDay && p.date <= endDay);
 }
 
 function computeLongestGap(points: DailyPoint[]): number {
-  let longest = 0;
-  let current = 0;
-  for (const p of points) {
-    if (p.count > 0) {
-      current = 0;
-      continue;
-    }
-    current += 1;
-    longest = Math.max(longest, current);
-  }
-  return longest;
+	let longest = 0;
+	let current = 0;
+	for (const p of points) {
+		if (p.count > 0) {
+			current = 0;
+			continue;
+		}
+		current += 1;
+		longest = Math.max(longest, current);
+	}
+	return longest;
 }
 
 function formatDayLabel(date: string): string {
-  let ts = new Date(date);
-  if (!Number.isFinite(ts.getTime())) {
-    const dayOnly = date.slice(0, 10);
-    ts = new Date(`${dayOnly}T00:00:00`);
-  }
-  if (!Number.isFinite(ts.getTime())) return date.slice(0, 10);
-  return ts.toLocaleDateString(undefined, {
-    weekday: "short",
-    month: "short",
-    day: "numeric",
-  });
+	let ts = new Date(date);
+	if (!Number.isFinite(ts.getTime())) {
+		const dayOnly = date.slice(0, 10);
+		ts = new Date(`${dayOnly}T00:00:00`);
+	}
+	if (!Number.isFinite(ts.getTime())) return date.slice(0, 10);
+	return ts.toLocaleDateString(undefined, {
+		weekday: "short",
+		month: "short",
+		day: "numeric",
+	});
 }
 
 export function ConsistencySection({
-  loading = false,
-  totalPlays,
-  totalDuration,
-  listeningDays,
-  dailyPlayCounts,
-  streak,
-  activePeriod,
-  activeProviderId = "statsfm",
+	loading = false,
+	totalPlays,
+	totalDuration,
+	listeningDays,
+	dailyPlayCounts,
+	streak,
+	activePeriod,
+	activeProviderId = "statsfm",
 }: ConsistencySectionProps) {
-  if (loading) {
-    return (
-      <div className="section-card consistency-section" aria-hidden="true">
-        <header className="section-heading">
-          <span className="section-kicker">Patterns</span>
-          <h2 className="section-title">Consistency</h2>
-        </header>
-        <div className="consistency-grid">
-          {Array.from({ length: 4 }).map((_, i) => (
-            <div key={i} className="consistency-metric">
-              <SkeletonTextLine width="55%" />
-              <SkeletonBlock width="45%" height={24} style={{ marginTop: 8 }} />
-              <SkeletonTextLine width="70%" />
-            </div>
-          ))}
-        </div>
-      </div>
-    );
-  }
-  const points = buildWindow(dailyPlayCounts ?? [], activePeriod);
-  const totalDays = points.length;
-  const activeDays =
-    points.length > 0
-      ? points.filter((p) => p.count > 0).length
-      : (listeningDays ?? 0);
-  const avgPlaysPerActiveDay = activeDays > 0 ? totalPlays / activeDays : 0;
-  const avgMinutesPerActiveDay =
-    activeDays > 0 ? totalDuration / 60000 / activeDays : 0;
-  const longestGap = computeLongestGap(points);
-  const coveragePct =
-    totalDays > 0 ? Math.round((activeDays / totalDays) * 100) : 0;
-  const trend = points.slice(-14);
-  const trendMax = Math.max(...trend.map((p) => p.count), 1);
-  const isTodayPeriod =
-    activePeriod.id === "today" || activePeriod.id === "sfm-today";
-  const isLocalProvider = activeProviderId === "local";
-  const Tooltip = Spicetify.ReactComponent.TooltipWrapper;
+	if (loading) {
+		return (
+			<div className="section-card consistency-section" aria-hidden="true">
+				<header className="section-heading">
+					<span className="section-kicker">Patterns</span>
+					<h2 className="section-title">Consistency</h2>
+				</header>
+				<div className="consistency-grid">
+					{Array.from({ length: 4 }).map((_, i) => (
+						<div key={i} className="consistency-metric">
+							<SkeletonTextLine width="55%" />
+							<SkeletonBlock width="45%" height={24} style={{ marginTop: 8 }} />
+							<SkeletonTextLine width="70%" />
+						</div>
+					))}
+				</div>
+			</div>
+		);
+	}
+	const points = buildWindow(dailyPlayCounts ?? [], activePeriod);
+	const totalDays = points.length;
+	const activeDays = points.length > 0 ? points.filter((p) => p.count > 0).length : (listeningDays ?? 0);
+	const avgPlaysPerActiveDay = activeDays > 0 ? totalPlays / activeDays : 0;
+	const avgMinutesPerActiveDay = activeDays > 0 ? totalDuration / 60000 / activeDays : 0;
+	const longestGap = computeLongestGap(points);
+	const coveragePct = totalDays > 0 ? Math.round((activeDays / totalDays) * 100) : 0;
+	const trend = points.slice(-14);
+	const trendMax = Math.max(...trend.map((p) => p.count), 1);
+	const isTodayPeriod = activePeriod.id === "today" || activePeriod.id === "sfm-today";
+	const isLocalProvider = activeProviderId === "local";
+	const Tooltip = Spicetify.ReactComponent.TooltipWrapper;
 
-  const MetricCard = ({
-    label,
-    value,
-    sub,
-    tooltip,
-    accent,
-  }: MetricCardProps) => (
-    <Tooltip label={tooltip}>
-      <div
-        className={`consistency-metric${accent ? " consistency-metric--accent" : ""}`}
-      >
-        <div className="consistency-metric-label">{label}</div>
-        <div className="consistency-metric-value">{value}</div>
-        <div className="consistency-metric-sub">{sub}</div>
-      </div>
-    </Tooltip>
-  );
+	const MetricCard = ({ label, value, sub, tooltip, accent }: MetricCardProps) => (
+		<Tooltip label={tooltip}>
+			<div className={`consistency-metric${accent ? " consistency-metric--accent" : ""}`}>
+				<div className="consistency-metric-label">{label}</div>
+				<div className="consistency-metric-value">{value}</div>
+				<div className="consistency-metric-sub">{sub}</div>
+			</div>
+		</Tooltip>
+	);
 
-  return (
-    <div className="section-card consistency-section">
-      <header className="section-heading">
-        <span className="section-kicker">Patterns</span>
-        <h2 className="section-title">Consistency</h2>
-      </header>
-      <div className="consistency-grid">
-        <MetricCard
-          label="Listening days"
-          value={activeDays}
-          sub={`out of ${totalDays || activeDays} days`}
-          tooltip="Number of days in this period with at least one stream."
-        />
-        <MetricCard
-          label="Avg plays / active day"
-          value={Math.round(avgPlaysPerActiveDay)}
-          sub="streams when active"
-          tooltip="Average stream count only across days where you listened."
-        />
-        <MetricCard
-          label="Avg minutes / active day"
-          value={Math.round(avgMinutesPerActiveDay)}
-          sub="listening time"
-          tooltip="Average listening duration in minutes across active days."
-        />
-        <MetricCard
-          label="Current streak"
-          value={streak != null && streak > 0 ? `${streak}d` : "-"}
-          sub="consecutive days"
-          tooltip="Consecutive calendar days with at least one play (local timezone)."
-        />
-      </div>
-      {!isTodayPeriod && (
-        <div className="consistency-footer">
-          <Tooltip
-            label={`You listened on ${activeDays} of ${totalDays || activeDays} days in this period.`}
-          >
-            <div className="consistency-coverage">
-              <div className="consistency-coverage-label">
-                Active-day coverage
-              </div>
-              <div className="consistency-coverage-row">
-                <div className="consistency-coverage-track">
-                  <div
-                    className="consistency-coverage-fill"
-                    style={{ width: `${coveragePct}%` }}
-                  />
-                </div>
-                <span>{coveragePct}%</span>
-              </div>
-            </div>
-          </Tooltip>
+	return (
+		<div className="section-card consistency-section">
+			<header className="section-heading">
+				<span className="section-kicker">Patterns</span>
+				<h2 className="section-title">Consistency</h2>
+			</header>
+			<div className="consistency-grid">
+				<MetricCard
+					label="Listening days"
+					value={activeDays}
+					sub={`out of ${totalDays || activeDays} days`}
+					tooltip="Number of days in this period with at least one stream."
+				/>
+				<MetricCard
+					label="Avg plays / active day"
+					value={Math.round(avgPlaysPerActiveDay)}
+					sub="streams when active"
+					tooltip="Average stream count only across days where you listened."
+				/>
+				<MetricCard
+					label="Avg minutes / active day"
+					value={Math.round(avgMinutesPerActiveDay)}
+					sub="listening time"
+					tooltip="Average listening duration in minutes across active days."
+				/>
+				<MetricCard
+					label="Current streak"
+					value={streak != null && streak > 0 ? `${streak}d` : "-"}
+					sub="consecutive days"
+					tooltip="Consecutive calendar days with at least one play (local timezone)."
+				/>
+			</div>
+			{!isTodayPeriod && (
+				<div className="consistency-footer">
+					<Tooltip label={`You listened on ${activeDays} of ${totalDays || activeDays} days in this period.`}>
+						<div className="consistency-coverage">
+							<div className="consistency-coverage-label">Active-day coverage</div>
+							<div className="consistency-coverage-row">
+								<div className="consistency-coverage-track">
+									<div className="consistency-coverage-fill" style={{ width: `${coveragePct}%` }} />
+								</div>
+								<span>{coveragePct}%</span>
+							</div>
+						</div>
+					</Tooltip>
 
-          {isLocalProvider ? (
-            <div className="consistency-week-split">
-              <div className="consistency-coverage-label">
-                Weekday vs weekend
-              </div>
-              {(() => {
-                const activePoints = points.filter((p) => p.count > 0);
-                const weekdayActive = activePoints.filter((p) => {
-                  const day = new Date(`${p.date}T00:00:00`).getDay();
-                  return day >= 1 && day <= 5;
-                }).length;
-                const weekendActive = activePoints.length - weekdayActive;
-                const totalActive = Math.max(weekdayActive + weekendActive, 1);
-                const weekdayPct = Math.round(
-                  (weekdayActive / totalActive) * 100,
-                );
-                const weekendPct = 100 - weekdayPct;
-                return (
-                  <div className="consistency-week-split-row">
-                    <Tooltip
-                      label={`${weekdayActive} active weekdays (${weekdayPct}%)`}
-                    >
-                      <div className="consistency-week-chip">
-                        <span>Weekdays</span>
-                        <strong>{weekdayPct}%</strong>
-                      </div>
-                    </Tooltip>
-                    <Tooltip
-                      label={`${weekendActive} active weekend days (${weekendPct}%)`}
-                    >
-                      <div className="consistency-week-chip">
-                        <span>Weekend</span>
-                        <strong>{weekendPct}%</strong>
-                      </div>
-                    </Tooltip>
-                  </div>
-                );
-              })()}
-            </div>
-          ) : (
-            trend.length > 0 && (
-              <div className="consistency-sparkline">
-                <div className="consistency-coverage-label">Last 14 days</div>
-                <div className="consistency-sparkline-bars">
-                  {trend.map((p) => {
-                    const isPeak = p.count > 0 && p.count === trendMax;
-                    return (
-                      <Tooltip
-                        key={p.date}
-                        label={`${formatDayLabel(p.date)}: ${p.count} plays`}
-                        placement="top"
-                      >
-                        <div className="consistency-sparkline-bar-wrap">
-                          <div
-                            className={`consistency-sparkline-bar${isPeak ? " peak" : ""}`}
-                            style={{
-                              height: `${Math.max((p.count / trendMax) * 100, p.count > 0 ? 8 : 2)}%`,
-                            }}
-                          />
-                        </div>
-                      </Tooltip>
-                    );
-                  })}
-                </div>
-              </div>
-            )
-          )}
-        </div>
-      )}
-    </div>
-  );
+					{isLocalProvider ? (
+						<div className="consistency-week-split">
+							<div className="consistency-coverage-label">Weekday vs weekend</div>
+							{(() => {
+								const activePoints = points.filter((p) => p.count > 0);
+								const weekdayActive = activePoints.filter((p) => {
+									const day = new Date(`${p.date}T00:00:00`).getDay();
+									return day >= 1 && day <= 5;
+								}).length;
+								const weekendActive = activePoints.length - weekdayActive;
+								const totalActive = Math.max(weekdayActive + weekendActive, 1);
+								const weekdayPct = Math.round((weekdayActive / totalActive) * 100);
+								const weekendPct = 100 - weekdayPct;
+								return (
+									<div className="consistency-week-split-row">
+										<Tooltip label={`${weekdayActive} active weekdays (${weekdayPct}%)`}>
+											<div className="consistency-week-chip">
+												<span>Weekdays</span>
+												<strong>{weekdayPct}%</strong>
+											</div>
+										</Tooltip>
+										<Tooltip label={`${weekendActive} active weekend days (${weekendPct}%)`}>
+											<div className="consistency-week-chip">
+												<span>Weekend</span>
+												<strong>{weekendPct}%</strong>
+											</div>
+										</Tooltip>
+									</div>
+								);
+							})()}
+						</div>
+					) : (
+						trend.length > 0 && (
+							<div className="consistency-sparkline">
+								<div className="consistency-coverage-label">Last 14 days</div>
+								<div className="consistency-sparkline-bars">
+									{trend.map((p) => {
+										const isPeak = p.count > 0 && p.count === trendMax;
+										return (
+											<Tooltip key={p.date} label={`${formatDayLabel(p.date)}: ${p.count} plays`} placement="top">
+												<div className="consistency-sparkline-bar-wrap">
+													<div
+														className={`consistency-sparkline-bar${isPeak ? " peak" : ""}`}
+														style={{
+															height: `${Math.max((p.count / trendMax) * 100, p.count > 0 ? 8 : 2)}%`,
+														}}
+													/>
+												</div>
+											</Tooltip>
+										);
+									})}
+								</div>
+							</div>
+						)
+					)}
+				</div>
+			)}
+		</div>
+	);
 }

--- a/src/app/components/ConsistencySection.tsx
+++ b/src/app/components/ConsistencySection.tsx
@@ -40,20 +40,6 @@ function buildWindow(points: DailyPoint[], period: Period): DailyPoint[] {
 	return points.filter((p) => p.date >= startDay && p.date <= endDay);
 }
 
-function computeLongestGap(points: DailyPoint[]): number {
-	let longest = 0;
-	let current = 0;
-	for (const p of points) {
-		if (p.count > 0) {
-			current = 0;
-			continue;
-		}
-		current += 1;
-		longest = Math.max(longest, current);
-	}
-	return longest;
-}
-
 function formatDayLabel(date: string): string {
 	let ts = new Date(date);
 	if (!Number.isFinite(ts.getTime())) {
@@ -102,7 +88,6 @@ export function ConsistencySection({
 	const activeDays = points.length > 0 ? points.filter((p) => p.count > 0).length : (listeningDays ?? 0);
 	const avgPlaysPerActiveDay = activeDays > 0 ? totalPlays / activeDays : 0;
 	const avgMinutesPerActiveDay = activeDays > 0 ? totalDuration / 60000 / activeDays : 0;
-	const longestGap = computeLongestGap(points);
 	const coveragePct = totalDays > 0 ? Math.round((activeDays / totalDays) * 100) : 0;
 	const trend = points.slice(-14);
 	const trendMax = Math.max(...trend.map((p) => p.count), 1);

--- a/src/app/components/FilterPill.tsx
+++ b/src/app/components/FilterPill.tsx
@@ -21,19 +21,10 @@ export function FilterPill({ activeGenre, onClear }: FilterPillProps) {
 
 	return (
 		<div className="filter-pill">
-			<span
-				className="filter-pill-icon"
-				aria-hidden="true"
-				dangerouslySetInnerHTML={{ __html: FilterIcon }}
-			/>
+			<span className="filter-pill-icon" aria-hidden="true" dangerouslySetInnerHTML={{ __html: FilterIcon }} />
 			<span>Filtering by</span>
 			<strong className="filter-pill-genre">{activeGenre}</strong>
-			<button
-				className="filter-pill-close"
-				type="button"
-				onClick={onClear}
-				aria-label="Clear genre filter"
-			>
+			<button className="filter-pill-close" type="button" onClick={onClear} aria-label="Clear genre filter">
 				×
 			</button>
 		</div>

--- a/src/app/components/Header.tsx
+++ b/src/app/components/Header.tsx
@@ -28,9 +28,7 @@ export function getLocalHealthColor(health: HealthPayload | null): "green" | "ye
 	return "red";
 }
 
-export function getStatsFmHealthColor(
-	health: StatsFmHealthPayload | null,
-): "green" | "yellow" | "red" {
+export function getStatsFmHealthColor(health: StatsFmHealthPayload | null): "green" | "yellow" | "red" {
 	if (!health || health.lastSuccessAt === null) return "red";
 	if (health.circuitOpen) return "red";
 	if (health.lastError !== null) return "red";
@@ -67,14 +65,12 @@ export function buildStatsFmTooltip(health: StatsFmHealthPayload | null): string
 	if (!health || health.lastFetchAt === null) return "No data fetched yet";
 	if (health.circuitOpen) return "stats.fm unavailable: circuit open";
 	if (health.lastError !== null) {
-		const msg =
-			health.lastError.length > 60 ? `${health.lastError.slice(0, 60)}…` : health.lastError;
+		const msg = health.lastError.length > 60 ? `${health.lastError.slice(0, 60)}…` : health.lastError;
 		return `API error: ${msg}`;
 	}
 	if (health.lastSuccessAt === null) return "No data fetched yet";
 	const refreshIn = Math.max(0, STATSFM_REFRESH_WINDOW_MS - (Date.now() - health.lastSuccessAt));
-	const refreshSuffix =
-		refreshIn > 0 ? ` · refresh in ${formatMsRemaining(refreshIn)}` : " · refresh due now";
+	const refreshSuffix = refreshIn > 0 ? ` · refresh in ${formatMsRemaining(refreshIn)}` : " · refresh due now";
 	const ageMin = (Date.now() - health.lastSuccessAt) / 60_000;
 	if (ageMin < 1) return `API healthy, just refreshed${refreshSuffix}`;
 	if (ageMin < 60) return `API healthy, refreshed ${Math.floor(ageMin)}m ago${refreshSuffix}`;
@@ -168,8 +164,7 @@ export default function Header({
 	}, [activeProviderId]);
 
 	const healthColor = getHealthColor(activeProviderId, health, sfmHealth);
-	const tooltipText =
-		activeProviderId === "statsfm" ? buildStatsFmTooltip(sfmHealth) : buildLocalTooltip(health);
+	const tooltipText = activeProviderId === "statsfm" ? buildStatsFmTooltip(sfmHealth) : buildLocalTooltip(health);
 
 	return (
 		<header className="stats-header">
@@ -183,9 +178,7 @@ export default function Header({
 								aria-label={`Health: ${healthColor} - ${tooltipText}`}
 							/>
 							<span className="header-provider-name">{providerName}</span>
-							{capabilities?.tier === "plus" && (
-								<span className="tier-badge tier-badge--plus">Plus</span>
-							)}
+							{capabilities?.tier === "plus" && <span className="tier-badge tier-badge--plus">Plus</span>}
 						</div>
 					</Spicetify.ReactComponent.TooltipWrapper>
 				</div>
@@ -193,11 +186,7 @@ export default function Header({
 			<div className="stats-header-right">
 				{periods && activePeriod && onPeriodChange && (
 					<div data-tour-target="period">
-						<PeriodTabs
-							periods={periods}
-							activePeriod={activePeriod}
-							onPeriodChange={onPeriodChange}
-						/>
+						<PeriodTabs periods={periods} activePeriod={activePeriod} onPeriodChange={onPeriodChange} />
 					</div>
 				)}
 				{onShareClick && (

--- a/src/app/components/InlineErrorCard.tsx
+++ b/src/app/components/InlineErrorCard.tsx
@@ -79,9 +79,7 @@ export function InlineErrorCard({ error, onRetry, onOpenSettings }: InlineErrorC
 				<div className="inline-error-title">{config.title}</div>
 				<div className="inline-error-body">{config.body}</div>
 				{error.resetAt !== undefined && countdown > 0 && (
-					<div className="inline-error-countdown">
-						retry in 0:{countdown.toString().padStart(2, "0")}
-					</div>
+					<div className="inline-error-countdown">retry in 0:{countdown.toString().padStart(2, "0")}</div>
 				)}
 			</div>
 			{config.cta && (

--- a/src/app/components/ListeningPatterns.tsx
+++ b/src/app/components/ListeningPatterns.tsx
@@ -5,15 +5,7 @@ import { getPreferences } from "../preferences";
 const HOURS = Array.from({ length: 24 }, (_, i) => i);
 const DAYS = Array.from({ length: 7 }, (_, i) => i);
 const WEEKDAYS_ABBR = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
-const WEEKDAYS_FULL = [
-	"Monday",
-	"Tuesday",
-	"Wednesday",
-	"Thursday",
-	"Friday",
-	"Saturday",
-	"Sunday",
-];
+const WEEKDAYS_FULL = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"];
 
 interface ListeningPatternsProps {
 	hourlyDistribution: number[];
@@ -91,10 +83,7 @@ function renderHourlyChart(hourlyDistribution: number[], peakHour: number, use24
 							label={`${formatHour(hr, use24h)}: ${val} plays`}
 							placement="top"
 						>
-							<div
-								className={`activity-bar${isPeak ? " peak" : ""}`}
-								style={{ height: `${heightPct}%` }}
-							/>
+							<div className={`activity-bar${isPeak ? " peak" : ""}`} style={{ height: `${heightPct}%` }} />
 						</Spicetify.ReactComponent.TooltipWrapper>
 					);
 				})}
@@ -125,10 +114,7 @@ function renderWeekdayChart(weekdayDistribution: number[], peakWeekday: number) 
 							label={`${WEEKDAYS_FULL[day]}: ${val} plays`}
 							placement="top"
 						>
-							<div
-								className={`activity-bar${isPeak ? " peak" : ""}`}
-								style={{ height: `${heightPct}%` }}
-							/>
+							<div className={`activity-bar${isPeak ? " peak" : ""}`} style={{ height: `${heightPct}%` }} />
 						</Spicetify.ReactComponent.TooltipWrapper>
 					);
 				})}

--- a/src/app/components/LoadingSkeleton.tsx
+++ b/src/app/components/LoadingSkeleton.tsx
@@ -37,10 +37,7 @@ export function TopListsWaveSkeleton() {
 				>
 					<SkeletonBlock width="80px" height="14px" style={{ marginBottom: "14px" }} />
 					{Array.from({ length: 5 }).map((_, row) => (
-						<div
-							key={row}
-							style={{ display: "flex", gap: "10px", alignItems: "center", marginBottom: "10px" }}
-						>
+						<div key={row} style={{ display: "flex", gap: "10px", alignItems: "center", marginBottom: "10px" }}>
 							<SkeletonCircle size={20} style={{ flexShrink: 0 }} />
 							<SkeletonBlock width="36px" height="36px" style={{ flexShrink: 0 }} />
 							<div style={{ flex: 1 }}>
@@ -86,10 +83,7 @@ export function WorldChartsSkeleton() {
 					/>
 					<div style={{ display: "grid", gridTemplateColumns: "1fr", gap: "8px 0" }}>
 						{Array.from({ length: 8 }).map((_, row) => (
-							<div
-								key={row}
-								style={{ display: "flex", gap: "12px", alignItems: "center", padding: "6px 8px" }}
-							>
+							<div key={row} style={{ display: "flex", gap: "12px", alignItems: "center", padding: "6px 8px" }}>
 								<div
 									className="skeleton-shimmer"
 									style={{ width: "24px", height: "24px", borderRadius: "50%", flexShrink: 0 }}
@@ -108,10 +102,7 @@ export function WorldChartsSkeleton() {
 											borderRadius: "4px",
 										}}
 									/>
-									<div
-										className="skeleton-shimmer"
-										style={{ width: "50%", height: "10px", borderRadius: "4px" }}
-									/>
+									<div className="skeleton-shimmer" style={{ width: "50%", height: "10px", borderRadius: "4px" }} />
 								</div>
 								<div
 									className="skeleton-shimmer"
@@ -130,11 +121,7 @@ export function ActivityChartSkeleton() {
 	return (
 		<div className="activity-chart" aria-hidden="true">
 			{Array.from({ length: 24 }).map((_, i) => (
-				<div
-					key={i}
-					className="activity-bar skeleton-shimmer"
-					style={{ height: `${20 + Math.random() * 60}%` }}
-				/>
+				<div key={i} className="activity-bar skeleton-shimmer" style={{ height: `${20 + Math.random() * 60}%` }} />
 			))}
 		</div>
 	);

--- a/src/app/components/OverviewSection.tsx
+++ b/src/app/components/OverviewSection.tsx
@@ -37,9 +37,7 @@ function OverviewHero({
 	periodKey: string;
 }) {
 	const reduce = useMemo(
-		() =>
-			typeof window.matchMedia === "function" &&
-			window.matchMedia("(prefers-reduced-motion: reduce)").matches,
+		() => typeof window.matchMedia === "function" && window.matchMedia("(prefers-reduced-motion: reduce)").matches,
 		[],
 	);
 	const [val, setVal] = useState<number>(reduce ? totalDuration : 0);
@@ -124,9 +122,7 @@ function OverviewHero({
 				>
 					{h}
 				</span>
-				<span style={{ fontSize: 24, fontWeight: 600, color: "rgba(var(--spice-rgb-text), 0.6)" }}>
-					h
-				</span>
+				<span style={{ fontSize: 24, fontWeight: 600, color: "rgba(var(--spice-rgb-text), 0.6)" }}>h</span>
 				<span
 					data-testid="hero-minutes"
 					style={{
@@ -138,9 +134,7 @@ function OverviewHero({
 				>
 					{m.toString().padStart(2, "0")}
 				</span>
-				<span style={{ fontSize: 18, fontWeight: 600, color: "rgba(var(--spice-rgb-text), 0.6)" }}>
-					m
-				</span>
+				<span style={{ fontSize: 18, fontWeight: 600, color: "rgba(var(--spice-rgb-text), 0.6)" }}>m</span>
 				{showDelta && deltaPct != null && (
 					<span
 						data-testid="hero-delta"
@@ -195,11 +189,7 @@ function OverviewSectionSkeleton() {
 	);
 }
 
-export default function OverviewSection({
-	stats,
-	activePeriod,
-	loading = false,
-}: OverviewSectionProps) {
+export default function OverviewSection({ stats, activePeriod, loading = false }: OverviewSectionProps) {
 	if (loading || !stats) return <OverviewSectionSkeleton />;
 	const prefs = getPreferences();
 	const activeId = providerRegistry.getActive()?.getProviderInfo().id ?? "local";
@@ -245,18 +235,13 @@ export default function OverviewSection({
 			tooltip: "Your most-played genre in this period",
 		},
 		"listening-days": {
-			value:
-				stats.listeningDays != null && stats.listeningDays > 0
-					? formatNumber(stats.listeningDays)
-					: "-",
+			value: stats.listeningDays != null && stats.listeningDays > 0 ? formatNumber(stats.listeningDays) : "-",
 			tooltip: "Number of days with at least one play in the selected period",
 		},
 	};
 
 	const order = prefs.overviewOrder[providerKey];
-	const visible = order.filter(
-		(id) => statCardsById[id] !== undefined && !prefs.hiddenSections.includes(id),
-	);
+	const visible = order.filter((id) => statCardsById[id] !== undefined && !prefs.hiddenSections.includes(id));
 	const top4 = visible.slice(0, 4);
 	const bottom3 = visible.slice(4, 7);
 	const topColumns = Math.max(1, Math.min(2, top4.length));
@@ -271,10 +256,7 @@ export default function OverviewSection({
 				<div className="overview-card" data-card-id={id}>
 					<div className="overview-card-label">{label}</div>
 					<div className="overview-card-row">
-						<span
-							className="overview-card-value"
-							style={card.accent ? { color: card.accent } : undefined}
-						>
+						<span className="overview-card-value" style={card.accent ? { color: card.accent } : undefined}>
 							{card.value}
 						</span>
 						{card.sub && <span className="overview-card-sub">{card.sub}</span>}
@@ -297,10 +279,7 @@ export default function OverviewSection({
 				periodKey={activePeriod.id}
 			/>
 			{top4.length > 0 && (
-				<div
-					className="overview-right-block"
-					style={{ gridTemplateColumns: `repeat(${topColumns}, minmax(0, 1fr))` }}
-				>
+				<div className="overview-right-block" style={{ gridTemplateColumns: `repeat(${topColumns}, minmax(0, 1fr))` }}>
 					{top4.map(renderTile)}
 				</div>
 			)}

--- a/src/app/components/OverviewSection.tsx
+++ b/src/app/components/OverviewSection.tsx
@@ -217,13 +217,7 @@ export default function OverviewSection({
 			value: formatNumber(stats.uniqueArtistCount),
 			tooltip: "Number of distinct artists played in the selected period",
 		},
-		streak: isStatsFm
-			? undefined
-			: {
-					value: stats.streak != null && stats.streak > 0 ? `${stats.streak}d` : "-",
-					tooltip: "Consecutive calendar days with at least one play (local timezone)",
-					accent: stats.streak != null && stats.streak > 0 ? "var(--spice-button)" : undefined,
-				},
+		streak: undefined,
 		"new-artists": {
 			value: formatNumber(stats.newArtistCount ?? 0),
 			tooltip:

--- a/src/app/components/PlayCountPill.tsx
+++ b/src/app/components/PlayCountPill.tsx
@@ -42,11 +42,7 @@ export function PlayCountPill({
 				"play-count-bubble",
 				[
 					React.createElement("div", { key: "i", className: "play-count-bubble-icon" }, "\u{25B6}"),
-					React.createElement(
-						"span",
-						{ key: "b", className: "play-count-badge play-count-badge--new" },
-						"NEW",
-					),
+					React.createElement("span", { key: "b", className: "play-count-badge play-count-badge--new" }, "NEW"),
 				],
 				firstListenTooltip,
 			);
@@ -114,11 +110,7 @@ export function PlayCountPill({
 
 	if (variant === "minimal") {
 		const extra = periodStreams != null && periodLabel ? ` (${periodStreams} ${periodLabel})` : "";
-		return React.createElement(
-			"div",
-			{ className: "play-count-minimal", title: tooltip },
-			`×${count}${extra}`,
-		);
+		return React.createElement("div", { className: "play-count-minimal", title: tooltip }, `×${count}${extra}`);
 	}
 
 	return React.createElement(

--- a/src/app/components/PlaybarWidget.tsx
+++ b/src/app/components/PlaybarWidget.tsx
@@ -23,9 +23,7 @@ interface TrackPlayInfo {
 
 function useNowPlayingCount(): TrackPlayInfo | null {
 	const [info, setInfo] = useState<TrackPlayInfo | null>(null);
-	const [trackUri, setTrackUri] = useState<string | null>(
-		() => Spicetify.Player.data?.item?.uri ?? null,
-	);
+	const [trackUri, setTrackUri] = useState<string | null>(() => Spicetify.Player.data?.item?.uri ?? null);
 	const [reloadKey, setReloadKey] = useState(0);
 
 	const lookupCount = useCallback(async (uri: string) => {
@@ -46,8 +44,7 @@ function useNowPlayingCount(): TrackPlayInfo | null {
 					let periodStreams: number | null = null;
 					let periodLabel: string | null = null;
 					if (prefs.playCountShowPeriodStreams) {
-						const supported =
-							providerRegistry.getActive()?.getSupportedPeriods() ?? STATSFM_PERIODS;
+						const supported = providerRegistry.getActive()?.getSupportedPeriods() ?? STATSFM_PERIODS;
 						if (supported.length > 0) {
 							const period = restorePeriodForProvider("statsfm", supported);
 							periodLabel = period.label;

--- a/src/app/components/RecentlyPlayed.tsx
+++ b/src/app/components/RecentlyPlayed.tsx
@@ -20,12 +20,7 @@ export function RecentlyPlayed({ recentPlays = [], loading = false }: RecentlyPl
 				{loading
 					? Array.from({ length: 6 }).map((_, i) => (
 							<div key={i} className="recently-played-item" aria-hidden="true">
-								<SkeletonBlock
-									className="recently-played-skeleton-art"
-									width={132}
-									height={132}
-									radius={6}
-								/>
+								<SkeletonBlock className="recently-played-skeleton-art" width={132} height={132} radius={6} />
 								<SkeletonBlock
 									className="recently-played-skeleton-text"
 									width={100}

--- a/src/app/components/SegmentedControl.tsx
+++ b/src/app/components/SegmentedControl.tsx
@@ -7,13 +7,7 @@ interface SegmentedControlProps {
 	labelAt?: number[];
 }
 
-export function SegmentedControl({
-	stops,
-	value,
-	onSelect,
-	formatLabel,
-	labelAt,
-}: SegmentedControlProps) {
+export function SegmentedControl({ stops, value, onSelect, formatLabel, labelAt }: SegmentedControlProps) {
 	const selectedIndex = Math.max(0, stops.indexOf(value));
 	const stopWidthPct = 100 / stops.length;
 	const indicatorStyle = {

--- a/src/app/components/SetupWizard.tsx
+++ b/src/app/components/SetupWizard.tsx
@@ -69,20 +69,12 @@ export function SetupWizard({ onComplete }: SetupWizardProps) {
 						<div className="wizard-provider-cards">
 							<button type="button" className="wizard-provider-card" onClick={completeLocal}>
 								<div className="wizard-provider-name">Local Tracking</div>
-								<div className="wizard-provider-desc">
-									Stats tracked on this device. No account required.
-								</div>
+								<div className="wizard-provider-desc">Stats tracked on this device. No account required.</div>
 								<div className="wizard-provider-cta">Start with Local</div>
 							</button>
-							<button
-								type="button"
-								className="wizard-provider-card"
-								onClick={() => setStep("statsfm")}
-							>
+							<button type="button" className="wizard-provider-card" onClick={() => setStep("statsfm")}>
 								<div className="wizard-provider-name">stats.fm</div>
-								<div className="wizard-provider-desc">
-									Import your listening history from your stats.fm profile.
-								</div>
+								<div className="wizard-provider-desc">Import your listening history from your stats.fm profile.</div>
 								<div className="wizard-provider-cta">Use stats.fm</div>
 							</button>
 						</div>
@@ -90,9 +82,7 @@ export function SetupWizard({ onComplete }: SetupWizardProps) {
 				) : (
 					<>
 						<h2 className="wizard-title">Connect stats.fm</h2>
-						<p className="wizard-subtitle">
-							Use your stats.fm customId. Your profile must be public for this to work.
-						</p>
+						<p className="wizard-subtitle">Use your stats.fm customId. Your profile must be public for this to work.</p>
 						<div className="provider-status-card wizard-statsfm-help">
 							<div className="settings-label">How to find your customId</div>
 							<div className="settings-sublabel">

--- a/src/app/components/ShareModal.tsx
+++ b/src/app/components/ShareModal.tsx
@@ -70,10 +70,7 @@ export function ShareModal({ stats, activePeriod, onClose }: ShareModalProps) {
 	const username = getShareCaptionHandle();
 	const periodLabel = activePeriod.label;
 	const periodBoundaries = activePeriod.getBoundaries();
-	const periodDayCount = Math.max(
-		1,
-		Math.round((periodBoundaries.end - periodBoundaries.start) / 86_400_000),
-	);
+	const periodDayCount = Math.max(1, Math.round((periodBoundaries.end - periodBoundaries.start) / 86_400_000));
 	const activeProviderId = providerRegistry.getActiveId() ?? "local";
 	const caps = providerRegistry.getActive()?.getProviderInfo().capabilities;
 
@@ -148,17 +145,7 @@ export function ShareModal({ stats, activePeriod, onClose }: ShareModalProps) {
 		} finally {
 			setBusy(false);
 		}
-	}, [
-		stats,
-		variant,
-		size,
-		periodLabel,
-		username,
-		followTheme,
-		activeProviderId,
-		periodDayCount,
-		busy,
-	]);
+	}, [stats, variant, size, periodLabel, username, followTheme, activeProviderId, periodDayCount, busy]);
 
 	const handleCopy = useCallback(async () => {
 		if (busy) return;
@@ -175,17 +162,7 @@ export function ShareModal({ stats, activePeriod, onClose }: ShareModalProps) {
 		} finally {
 			setBusy(false);
 		}
-	}, [
-		stats,
-		variant,
-		size,
-		periodLabel,
-		username,
-		followTheme,
-		activeProviderId,
-		periodDayCount,
-		busy,
-	]);
+	}, [stats, variant, size, periodLabel, username, followTheme, activeProviderId, periodDayCount, busy]);
 
 	return Spicetify.ReactDOM.createPortal(
 		<div className="share-overlay" onClick={handleOverlayClick}>
@@ -235,17 +212,11 @@ export function ShareModal({ stats, activePeriod, onClose }: ShareModalProps) {
 
 				<div className="share-control-row">
 					<label className="share-toggle-row">
-						<input
-							type="checkbox"
-							checked={followTheme}
-							onChange={(e) => setFollowTheme(e.currentTarget.checked)}
-						/>
+						<input type="checkbox" checked={followTheme} onChange={(e) => setFollowTheme(e.currentTarget.checked)} />
 						<span>Follow theme</span>
 					</label>
 					<span className="share-control-help">
-						{followTheme
-							? "Card uses current Spotify theme colors."
-							: "Card uses default locked green share palette."}
+						{followTheme ? "Card uses current Spotify theme colors." : "Card uses default locked green share palette."}
 					</span>
 				</div>
 
@@ -392,9 +363,7 @@ function _ShareCardPreview({ variant, size, stats, periodLabel, username }: Shar
 				{variant === "genre" && <ShareGenre stats={stats} />}
 				{variant === "streak" && <ShareStreak stats={stats} />}
 				{variant === "throwback" && <ShareThrowback stats={stats} />}
-				{variant === "wrapped" && (
-					<ShareWrapped stats={stats} size={size} periodLabel={periodLabel} />
-				)}
+				{variant === "wrapped" && <ShareWrapped stats={stats} size={size} periodLabel={periodLabel} />}
 			</div>
 		</div>
 	);
@@ -420,17 +389,7 @@ function tileGrad(seed: string): string {
 	return `linear-gradient(135deg, ${pair[0]}, ${pair[1]})`;
 }
 
-function Tile({
-	seed,
-	sz,
-	rounded = 4,
-	imageUrl,
-}: {
-	seed: string;
-	sz: number;
-	rounded?: number;
-	imageUrl?: string;
-}) {
+function Tile({ seed, sz, rounded = 4, imageUrl }: { seed: string; sz: number; rounded?: number; imageUrl?: string }) {
 	const art = normalizeSpotifyImageUrl(imageUrl);
 	const bg = art ? `url(${art}) center/cover no-repeat, ${tileGrad(seed)}` : tileGrad(seed);
 	return (
@@ -447,15 +406,7 @@ function Tile({
 	);
 }
 
-function ShareWrapped({
-	stats,
-	size,
-	periodLabel,
-}: {
-	stats: StatsResult;
-	size: ShareSize;
-	periodLabel: string;
-}) {
+function ShareWrapped({ stats, size, periodLabel }: { stats: StatsResult; size: ShareSize; periodLabel: string }) {
 	const isStory = size === "story";
 	const totalHours = Math.floor(stats.totalDuration / 3_600_000);
 	const streak = stats.streak ?? 0;
@@ -492,16 +443,13 @@ function ShareWrapped({
 					lineHeight: 1.35,
 				}}
 			>
-				{formatNumber(stats.totalPlays)} plays · {stats.uniqueArtistCount} artists · peak{" "}
-				{peakLabel}
+				{formatNumber(stats.totalPlays)} plays · {stats.uniqueArtistCount} artists · peak {peakLabel}
 				{streak > 0 ? ` · ${streak}-day streak` : ""}
 			</div>
 
 			{tracks.length > 0 && (
 				<div style={{ marginTop: isStory ? 12 : 8 }}>
-					<div style={{ ...KICKER_STYLE, fontSize: isStory ? 11 : 9, marginBottom: 6 }}>
-						Top tracks
-					</div>
+					<div style={{ ...KICKER_STYLE, fontSize: isStory ? 11 : 9, marginBottom: 6 }}>Top tracks</div>
 					<ol
 						style={{
 							listStyle: "none",
@@ -563,9 +511,7 @@ function ShareWrapped({
 
 			{artists.length > 0 && (
 				<div style={{ marginTop: isStory ? 12 : 8 }}>
-					<div style={{ ...KICKER_STYLE, fontSize: isStory ? 11 : 9, marginBottom: 6 }}>
-						Top artists
-					</div>
+					<div style={{ ...KICKER_STYLE, fontSize: isStory ? 11 : 9, marginBottom: 6 }}>Top artists</div>
 					<ol
 						style={{
 							listStyle: "none",
@@ -594,12 +540,7 @@ function ShareWrapped({
 								>
 									{i + 1}
 								</span>
-								<Tile
-									seed={a.artistUri}
-									sz={isStory ? 26 : 22}
-									rounded={6}
-									imageUrl={a.imageUrl ?? undefined}
-								/>
+								<Tile seed={a.artistUri} sz={isStory ? 26 : 22} rounded={6} imageUrl={a.imageUrl ?? undefined} />
 								<div style={{ minWidth: 0, flex: 1 }}>
 									<div
 										style={{
@@ -624,9 +565,7 @@ function ShareWrapped({
 
 			{genres.length > 0 && (
 				<div style={{ marginTop: isStory ? 12 : 8 }}>
-					<div style={{ ...KICKER_STYLE, fontSize: isStory ? 11 : 9, marginBottom: 6 }}>
-						Top genres
-					</div>
+					<div style={{ ...KICKER_STYLE, fontSize: isStory ? 11 : 9, marginBottom: 6 }}>Top genres</div>
 					<div style={{ display: "flex", flexDirection: "column", gap: isStory ? 6 : 4 }}>
 						{genres.map((g, i) => {
 							const pct = genreTotal > 0 ? g.count / genreTotal : 0;
@@ -709,11 +648,7 @@ function ShareTop5({ stats }: { stats: StatsResult }) {
 				}}
 			>
 				{tracks.map((t, i) => (
-					<li
-						key={t.trackUri}
-						data-testid="share-top5-item"
-						style={{ display: "flex", alignItems: "center", gap: 10 }}
-					>
+					<li key={t.trackUri} data-testid="share-top5-item" style={{ display: "flex", alignItems: "center", gap: 10 }}>
 						<span
 							style={{
 								fontSize: 18,
@@ -756,10 +691,7 @@ function ShareTime({ stats, periodLabel }: { stats: StatsResult; periodLabel: st
 	return (
 		<div>
 			<div style={KICKER_STYLE}>{head}</div>
-			<div
-				data-testid="share-time-hero"
-				style={{ display: "flex", alignItems: "baseline", gap: 8 }}
-			>
+			<div data-testid="share-time-hero" style={{ display: "flex", alignItems: "baseline", gap: 8 }}>
 				<span
 					style={{
 						fontSize: 80,
@@ -774,9 +706,7 @@ function ShareTime({ stats, periodLabel }: { stats: StatsResult; periodLabel: st
 				<span style={{ fontSize: 32, fontWeight: 700 }}>hours</span>
 			</div>
 			{topArtist && (
-				<div
-					style={{ marginTop: 14, fontSize: 13, color: "rgba(255,255,255,.7)", lineHeight: 1.5 }}
-				>
+				<div style={{ marginTop: 14, fontSize: 13, color: "rgba(255,255,255,.7)", lineHeight: 1.5 }}>
 					Mostly to <strong style={{ color: "var(--spice-button, #1ed760)" }}>{topArtist}</strong>.
 				</div>
 			)}
@@ -800,11 +730,7 @@ function ShareGenre({ stats }: { stats: StatsResult }) {
 				{top.map((g, i) => {
 					const pct = totalCount > 0 ? g.count / totalCount : 0;
 					return (
-						<div
-							key={g.genre}
-							data-testid="share-genre-row"
-							style={{ display: "flex", alignItems: "center", gap: 10 }}
-						>
+						<div key={g.genre} data-testid="share-genre-row" style={{ display: "flex", alignItems: "center", gap: 10 }}>
 							<span
 								style={{
 									flex: "0 0 auto",
@@ -909,9 +835,7 @@ function ShareThrowback({ stats }: { stats: StatsResult }) {
 			<div style={KICKER_STYLE}>Most-played</div>
 			<Tile seed={track.trackUri} sz={140} rounded={8} imageUrl={track.albumArt} />
 			<div style={{ marginTop: 14 }}>
-				<div style={{ fontSize: 22, fontWeight: 800, letterSpacing: "-.02em" }}>
-					{track.trackName}
-				</div>
+				<div style={{ fontSize: 22, fontWeight: 800, letterSpacing: "-.02em" }}>{track.trackName}</div>
 				<div style={{ fontSize: 13, color: "rgba(255,255,255,.7)" }}>
 					{track.artistName} · {track.count === 1 ? "1 play" : `${track.count} plays`}
 				</div>
@@ -1039,14 +963,7 @@ export function loadImage(url: string): Promise<HTMLImageElement | null> {
 	});
 }
 
-function cvRoundRect(
-	ctx: CanvasRenderingContext2D,
-	x: number,
-	y: number,
-	w: number,
-	h: number,
-	r: number,
-) {
+function cvRoundRect(ctx: CanvasRenderingContext2D, x: number, y: number, w: number, h: number, r: number) {
 	ctx.beginPath();
 	ctx.moveTo(x + r, y);
 	ctx.arcTo(x + w, y, x + w, y + h, r);
@@ -1056,14 +973,7 @@ function cvRoundRect(
 	ctx.closePath();
 }
 
-function cvFillRoundRect(
-	ctx: CanvasRenderingContext2D,
-	x: number,
-	y: number,
-	w: number,
-	h: number,
-	r: number,
-) {
+function cvFillRoundRect(ctx: CanvasRenderingContext2D, x: number, y: number, w: number, h: number, r: number) {
 	cvRoundRect(ctx, x, y, w, h, r);
 	ctx.fill();
 }
@@ -1098,13 +1008,7 @@ async function cvDrawArt(
 	return true;
 }
 
-function cvPlaceholder(
-	ctx: CanvasRenderingContext2D,
-	x: number,
-	y: number,
-	size: number,
-	radius: number,
-) {
+function cvPlaceholder(ctx: CanvasRenderingContext2D, x: number, y: number, size: number, radius: number) {
 	ctx.fillStyle = "rgba(255,255,255,0.06)";
 	cvFillRoundRect(ctx, x, y, size, size, radius);
 	ctx.fillStyle = "rgba(255,255,255,0.2)";
@@ -1162,20 +1066,7 @@ function formatShareSpecPeakHour(hour: number): string {
 function formatShareHeatmapBestDay(dateStr: string): string {
 	const m = dateStr.match(/^(\d{4})-(\d{2})-(\d{2})/);
 	if (!m) return dateStr;
-	const months = [
-		"Jan",
-		"Feb",
-		"Mar",
-		"Apr",
-		"May",
-		"Jun",
-		"Jul",
-		"Aug",
-		"Sep",
-		"Oct",
-		"Nov",
-		"Dec",
-	];
+	const months = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
 	const mi = Number(m[2]);
 	const di = Number(m[3]);
 	if (mi < 1 || mi > 12) return dateStr;
@@ -1183,12 +1074,7 @@ function formatShareHeatmapBestDay(dateStr: string): string {
 }
 
 /** Diagonal gradient fill across palette backgrounds */
-function drawBackground(
-	ctx: CanvasRenderingContext2D,
-	w: number,
-	h: number,
-	palette: SharePalette,
-) {
+function drawBackground(ctx: CanvasRenderingContext2D, w: number, h: number, palette: SharePalette) {
 	const cssAngleDeg = 160;
 	const ang = cssAngleDeg * (Math.PI / 180);
 	const ux = Math.sin(ang);
@@ -1220,12 +1106,7 @@ function drawBackground(
 	ctx.fillRect(0, 0, w, h);
 }
 
-function drawWatermarkBar(
-	ctx: CanvasRenderingContext2D,
-	w: number,
-	captionText: string,
-	palette: SharePalette,
-) {
+function drawWatermarkBar(ctx: CanvasRenderingContext2D, w: number, captionText: string, palette: SharePalette) {
 	const cx = CV_PAD;
 	const cy = 52;
 
@@ -1378,14 +1259,7 @@ async function drawTop5Content(
 		cvChunkBg(ctx, x - 8, y + 48, w + 16, chunkH, palette);
 		const cx = x + 24;
 		const cy = y + 48;
-		cvMutedCapsHeading(
-			ctx,
-			"Top 5 share",
-			cx,
-			cy + 44,
-			24,
-			palette.specChunkCapsLabelMuted ?? palette.dimText,
-		);
+		cvMutedCapsHeading(ctx, "Top 5 share", cx, cy + 44, 24, palette.specChunkCapsLabelMuted ?? palette.dimText);
 		ctx.font = `${28}px ${CV_FONT}`;
 		const playsLineW = ctx.measureText(`${formatNumber(totalFive)} plays`).width;
 		ctx.font = `${22}px ${CV_FONT}`;
@@ -1620,8 +1494,7 @@ async function drawGenreContent(
 		const g = leaders[i];
 		const t = stats.topTracks[i];
 		if (!t) break;
-		if (!(await cvDrawArt(ctx, t.albumArt, x + 24, ly, art, 8)))
-			cvPlaceholder(ctx, x + 24, ly, art, 8);
+		if (!(await cvDrawArt(ctx, t.albumArt, x + 24, ly, art, 8))) cvPlaceholder(ctx, x + 24, ly, art, 8);
 		ctx.fillStyle = palette.text;
 		ctx.font = `600 ${32}px ${CV_FONT}`;
 		ctx.fillText(cvTruncate(ctx, t.trackName, txtMax), textStart, titleBaseline(ly));
@@ -1664,14 +1537,7 @@ async function drawStreakContent(
 			const count = data[idx]?.count ?? 0;
 			const t = Math.min(1, count / max);
 			ctx.fillStyle = cvRgb(palette.accent, 0.08 + t * 0.92);
-			cvFillRoundRect(
-				ctx,
-				x + wi * (cellSize + gap),
-				y + di * (cellSize + gap),
-				cellSize,
-				cellSize,
-				6,
-			);
+			cvFillRoundRect(ctx, x + wi * (cellSize + gap), y + di * (cellSize + gap), cellSize, cellSize, 6);
 		}
 	}
 	y += rows * (cellSize + gap) + (isStory ? 48 : 24);
@@ -1716,11 +1582,7 @@ async function drawStreakContent(
 	ctx.fillText(`${streak} days`, x + colW + midGap + 28, y + 116);
 	ctx.fillStyle = mutedBody;
 	ctx.font = `${26}px ${CV_FONT}`;
-	ctx.fillText(
-		cvTruncate(ctx, "your best run this year", colW - 56),
-		x + colW + midGap + 28,
-		y + 162,
-	);
+	ctx.fillText(cvTruncate(ctx, "your best run this year", colW - 56), x + colW + midGap + 28, y + 162);
 
 	y += chunkH + 28;
 	cvChunkBg(ctx, x - 8, y, w + 16, 176, palette);
@@ -2079,14 +1941,7 @@ async function drawWrappedContent(
 	}
 }
 
-function cvChunkBg(
-	ctx: CanvasRenderingContext2D,
-	x: number,
-	y: number,
-	w: number,
-	h: number,
-	palette: SharePalette,
-) {
+function cvChunkBg(ctx: CanvasRenderingContext2D, x: number, y: number, w: number, h: number, palette: SharePalette) {
 	ctx.fillStyle = palette.chunkBg;
 	cvFillRoundRect(ctx, x, y, w, h, 20);
 	ctx.strokeStyle = palette.chunkBorder;
@@ -2130,11 +1985,7 @@ export async function renderShareCardCanvas(
 	const contentX = CV_PAD;
 	const contentTop = safeVariant === "wrapped" ? 168 : 180;
 	const contentBottom =
-		safeVariant === "wrapped" && size === "square"
-			? 108
-			: safeVariant === "wrapped" && size === "story"
-				? 96
-				: 140;
+		safeVariant === "wrapped" && size === "square" ? 108 : safeVariant === "wrapped" && size === "story" ? 96 : 140;
 	const wrapFooterReserve = safeVariant === "wrapped" ? (size === "story" ? 96 : 92) : 72;
 	const availableHeight = h - contentTop - contentBottom;
 	const estimatedHeight = estimateContentHeight(safeVariant, size);
@@ -2148,17 +1999,7 @@ export async function renderShareCardCanvas(
 			await drawTop5Content(ctx, stats, size, palette, contentX, contentY, contentW);
 			break;
 		case "time":
-			await drawTimeContent(
-				ctx,
-				stats,
-				size,
-				palette,
-				periodLabel,
-				periodDays,
-				contentX,
-				contentY,
-				contentW,
-			);
+			await drawTimeContent(ctx, stats, size, palette, periodLabel, periodDays, contentX, contentY, contentW);
 			break;
 		case "genre":
 			await drawGenreContent(ctx, stats, size, palette, contentX, contentY, contentW);

--- a/src/app/components/SkeletonPrimitives.tsx
+++ b/src/app/components/SkeletonPrimitives.tsx
@@ -26,13 +26,7 @@ export function SkeletonBlock({
 	);
 }
 
-export function SkeletonCircle({
-	size = 20,
-	style,
-}: {
-	size?: number;
-	style?: React.CSSProperties;
-}) {
+export function SkeletonCircle({ size = 20, style }: { size?: number; style?: React.CSSProperties }) {
 	return <SkeletonBlock width={size} height={size} radius="50%" style={style} />;
 }
 

--- a/src/app/components/TopGenres.tsx
+++ b/src/app/components/TopGenres.tsx
@@ -32,14 +32,9 @@ export function TopGenres({ topGenres, onGenreClick, activeGenre }: TopGenresPro
 								{genre.genre}
 							</button>
 							<div className="top-genres-bar-track">
-								<div
-									className={`top-genres-bar${i === 0 ? " peak" : ""}`}
-									style={{ width: `${pct}%` }}
-								/>
+								<div className={`top-genres-bar${i === 0 ? " peak" : ""}`} style={{ width: `${pct}%` }} />
 							</div>
-							<span className="top-genres-pct">
-								{Math.round((genre.count / totalCount) * 100)}%
-							</span>
+							<span className="top-genres-pct">{Math.round((genre.count / totalCount) * 100)}%</span>
 						</div>
 					);
 				})}

--- a/src/app/components/TopLists.tsx
+++ b/src/app/components/TopLists.tsx
@@ -154,9 +154,7 @@ export function TopLists({
 								}}
 							>
 								<span className={`rank-number ${getRankClass(artist.rank)}`}>{artist.rank}</span>
-								{artistAvatar ? (
-									<img src={artistAvatar} alt="" className="track-art track-art--round" />
-								) : null}
+								{artistAvatar ? <img src={artistAvatar} alt="" className="track-art track-art--round" /> : null}
 								<div
 									style={{
 										flex: 1,
@@ -191,9 +189,7 @@ export function TopLists({
 											textOverflow: "ellipsis",
 										}}
 									>
-										<span style={{ fontVariantNumeric: "tabular-nums" }}>
-											{formatNumber(artist.count)} plays
-										</span>
+										<span style={{ fontVariantNumeric: "tabular-nums" }}>{formatNumber(artist.count)} plays</span>
 										{primaryGenre && (
 											<>
 												<span style={{ opacity: 0.4 }}>·</span>
@@ -212,9 +208,7 @@ export function TopLists({
 													}}
 													style={{
 														color:
-															activeGenre === primaryGenre
-																? "var(--spice-button)"
-																: "rgba(var(--spice-rgb-text), 0.7)",
+															activeGenre === primaryGenre ? "var(--spice-button)" : "rgba(var(--spice-rgb-text), 0.7)",
 														cursor: "pointer",
 													}}
 												>
@@ -297,9 +291,5 @@ export function TopLists({
 		),
 	};
 
-	return (
-		<div className="top-lists-grid">
-			{visibleColumns.map((id) => columnRenderers[id]?.() ?? null)}
-		</div>
-	);
+	return <div className="top-lists-grid">{visibleColumns.map((id) => columnRenderers[id]?.() ?? null)}</div>;
 }

--- a/src/app/components/TourPopover.tsx
+++ b/src/app/components/TourPopover.tsx
@@ -41,14 +41,7 @@ export function computeStyle(rect: TargetRect, popoverHeight: number): React.CSS
 	};
 }
 
-export function TourPopover({
-	step,
-	steps = TOUR_STEPS,
-	onNext,
-	onBack,
-	onSkip,
-	targetRect,
-}: TourPopoverProps) {
+export function TourPopover({ step, steps = TOUR_STEPS, onNext, onBack, onSkip, targetRect }: TourPopoverProps) {
 	const ref = useRef<HTMLDivElement>(null);
 	const [style, setStyle] = useState<React.CSSProperties | undefined>(undefined);
 	const currentStep = steps[step];

--- a/src/app/components/UpdateModal.tsx
+++ b/src/app/components/UpdateModal.tsx
@@ -61,9 +61,7 @@ export function UpdateModal({
 	const copiedTimerRef = useRef<number | null>(null);
 
 	const bashCmd = receiveBetaUpdates ? INSTALL_COMMAND_BASH_PRERELEASE : INSTALL_COMMAND_BASH;
-	const psCmd = receiveBetaUpdates
-		? INSTALL_COMMAND_POWERSHELL_PRERELEASE
-		: INSTALL_COMMAND_POWERSHELL;
+	const psCmd = receiveBetaUpdates ? INSTALL_COMMAND_POWERSHELL_PRERELEASE : INSTALL_COMMAND_POWERSHELL;
 
 	useEffect(() => {
 		if (!open) return;
@@ -111,9 +109,7 @@ export function UpdateModal({
 					setCopiedWhich(null);
 					copiedTimerRef.current = null;
 				}, 2500);
-				Spicetify.showNotification(
-					which === "bash" ? "Copied (macOS / Linux)." : "Copied (Windows).",
-				);
+				Spicetify.showNotification(which === "bash" ? "Copied (macOS / Linux)." : "Copied (Windows).");
 			} else {
 				Spicetify.showNotification("Could not copy.", true);
 			}
@@ -125,8 +121,7 @@ export function UpdateModal({
 
 	if (!open) return null;
 
-	const changelogHtml =
-		changelogMd !== null ? markdownLiteToHtml(changelogMd.slice(0, 120_000)) : "";
+	const changelogHtml = changelogMd !== null ? markdownLiteToHtml(changelogMd.slice(0, 120_000)) : "";
 
 	const metaMissing = updateInfo != null && updateInfo.remoteTag === null;
 	const statusLine =
@@ -224,12 +219,7 @@ export function UpdateModal({
 				</div>
 
 				<p className="settings-about-hint update-modal-repo-hint">
-					<a
-						className="settings-inline-link"
-						href={GITHUB_REPO_WEB_URL}
-						target="_blank"
-						rel="noopener noreferrer"
-					>
+					<a className="settings-inline-link" href={GITHUB_REPO_WEB_URL} target="_blank" rel="noopener noreferrer">
 						GitHub
 					</a>
 					{" · "}
@@ -245,10 +235,7 @@ export function UpdateModal({
 
 				<h3 className="update-modal-changelog-title">Changelog</h3>
 				{changelogErr ? <p className="update-modal-changelog-error">{changelogErr}</p> : null}
-				<div
-					className="update-modal-changelog markdown-lite"
-					dangerouslySetInnerHTML={{ __html: changelogHtml }}
-				/>
+				<div className="update-modal-changelog markdown-lite" dangerouslySetInnerHTML={{ __html: changelogHtml }} />
 			</div>
 		</div>,
 		document.body,

--- a/src/app/components/WorldChartsPage.tsx
+++ b/src/app/components/WorldChartsPage.tsx
@@ -53,10 +53,7 @@ function getDeltaDisplay(delta: number): { direction: string; indicator: string 
 	return { direction: "neutral", indicator: "-" };
 }
 
-function buildSourceLine(
-	trackSource: WorldChartDataSource,
-	artistSource: WorldChartDataSource,
-): string {
+function buildSourceLine(trackSource: WorldChartDataSource, artistSource: WorldChartDataSource): string {
 	if (trackSource === "statsfm" && artistSource === "statsfm") return "Global charts · stats.fm";
 	const bits: string[] = [];
 	bits.push(
@@ -137,8 +134,7 @@ export function WorldChartsPage() {
 		const rank = index + 1;
 		const rankCls = getRankClass(rank);
 		const deltaNum = item.delta;
-		const delta =
-			deltaNum != null ? getDeltaDisplay(deltaNum) : { direction: "neutral", indicator: "" };
+		const delta = deltaNum != null ? getDeltaDisplay(deltaNum) : { direction: "neutral", indicator: "" };
 		const query = isArtist ? item.title : `${item.title} ${item.artist}`;
 
 		const bgStyle = item.artUrl
@@ -161,18 +157,13 @@ export function WorldChartsPage() {
 				}}
 			>
 				<span className={`rank-number ${rankCls}`}>{rank}</span>
-				<div
-					className={`world-chart-tile${isArtist ? " world-chart-tile--round" : ""}`}
-					style={bgStyle}
-				/>
+				<div className={`world-chart-tile${isArtist ? " world-chart-tile--round" : ""}`} style={bgStyle} />
 				<div className="world-chart-info">
 					<div className="world-chart-title">{item.title}</div>
 					<div className="world-chart-artist">{isArtist ? item.plays : item.artist}</div>
 				</div>
 				<div className="world-chart-stats">
-					{!isArtist && item.plays?.trim() ? (
-						<div className="world-chart-plays">{item.plays}</div>
-					) : null}
+					{!isArtist && item.plays?.trim() ? <div className="world-chart-plays">{item.plays}</div> : null}
 					{deltaNum != null && delta.indicator ? (
 						<div className="world-chart-delta" data-direction={delta.direction}>
 							{delta.indicator}
@@ -192,12 +183,7 @@ export function WorldChartsPage() {
 						<h2 className="section-title">What the world is playing</h2>
 					</div>
 					<div className="world-charts-tabs">
-						<div
-							className="world-charts-tab-group"
-							data-tabs="window"
-							role="tablist"
-							aria-label="Time range"
-						>
+						<div className="world-charts-tab-group" data-tabs="window" role="tablist" aria-label="Time range">
 							{WINDOWS.map((w) => (
 								<button
 									type="button"
@@ -216,15 +202,12 @@ export function WorldChartsPage() {
 			</div>
 
 			<div className="world-page-notice" role="status">
-				World charts are new and updated often; what you see here may change as sources and layout
-				improve.
+				World charts are new and updated often; what you see here may change as sources and layout improve.
 			</div>
 
 			{loading && <WorldChartsSkeleton />}
 
-			{!loading && error && (
-				<InlineErrorCard error={error} onRetry={handleRetry} onOpenSettings={() => {}} />
-			)}
+			{!loading && error && <InlineErrorCard error={error} onRetry={handleRetry} onOpenSettings={() => {}} />}
 
 			{!loading && !error && (
 				<>
@@ -234,9 +217,7 @@ export function WorldChartsPage() {
 								<span className="section-kicker">Trending</span>
 								<h3 className="section-title">Top Tracks</h3>
 							</header>
-							<div className="world-charts-grid">
-								{tracks.slice(0, 8).map((t, i) => renderChartItem(t, i, false))}
-							</div>
+							<div className="world-charts-grid">{tracks.slice(0, 8).map((t, i) => renderChartItem(t, i, false))}</div>
 						</section>
 
 						<section className="section-card world-charts-section" data-section="artists">
@@ -244,9 +225,7 @@ export function WorldChartsPage() {
 								<span className="section-kicker">Popular</span>
 								<h3 className="section-title">Top Artists</h3>
 							</header>
-							<div className="world-charts-grid">
-								{artists.slice(0, 8).map((a, i) => renderChartItem(a, i, true))}
-							</div>
+							<div className="world-charts-grid">{artists.slice(0, 8).map((a, i) => renderChartItem(a, i, true))}</div>
 						</section>
 					</div>
 

--- a/src/app/components/settings/AboutTab.tsx
+++ b/src/app/components/settings/AboutTab.tsx
@@ -11,12 +11,7 @@ interface AboutTabProps {
 	onReceiveBetaUpdatesChanged?: () => void;
 }
 
-export function AboutTab({
-	version,
-	onOpenUpdates,
-	onPrefsChanged,
-	onReceiveBetaUpdatesChanged,
-}: AboutTabProps) {
+export function AboutTab({ version, onOpenUpdates, onPrefsChanged, onReceiveBetaUpdatesChanged }: AboutTabProps) {
 	const Toggle = Spicetify.ReactComponent.Toggle;
 	const prefs = getPreferences();
 
@@ -43,8 +38,7 @@ export function AboutTab({
 				<div>
 					<div className="settings-label">Prereleases</div>
 					<div className="settings-sublabel">
-						Same setting as in the updates window - affects version checks and which install command
-						is copied there.
+						Same setting as in the updates window - affects version checks and which install command is copied there.
 					</div>
 				</div>
 				{Toggle ? (
@@ -59,26 +53,16 @@ export function AboutTab({
 			</div>
 
 			<p className="settings-about-short-lead">
-				Changelog, install commands, and release checks are in <strong>Check for updates</strong>{" "}
-				(footer or below).
+				Changelog, install commands, and release checks are in <strong>Check for updates</strong> (footer or below).
 			</p>
 
-			<button
-				type="button"
-				className="btn-secondary settings-about-check-updates"
-				onClick={onOpenUpdates}
-			>
+			<button type="button" className="btn-secondary settings-about-check-updates" onClick={onOpenUpdates}>
 				Check for updates…
 			</button>
 
 			<p className="settings-about-hint">
 				Source:{" "}
-				<a
-					className="settings-inline-link"
-					href={GITHUB_REPO_WEB_URL}
-					target="_blank"
-					rel="noopener noreferrer"
-				>
+				<a className="settings-inline-link" href={GITHUB_REPO_WEB_URL} target="_blank" rel="noopener noreferrer">
 					{GITHUB_REPO_WEB_URL.replace("https://", "")}
 				</a>
 			</p>

--- a/src/app/components/settings/DataTab.tsx
+++ b/src/app/components/settings/DataTab.tsx
@@ -4,12 +4,7 @@ import { LOCAL_PERIODS } from "../../../shared/stats/periods";
 import { providerRegistry } from "../../../shared/stats/provider";
 import { statsCache } from "../../../shared/stats/stats-cache";
 import { db } from "../../../shared/storage/db";
-import {
-	importFileEvents,
-	type ParseResult,
-	parseJsonEvents,
-	parseV1Csv,
-} from "../../../shared/storage/import";
+import { importFileEvents, type ParseResult, parseJsonEvents, parseV1Csv } from "../../../shared/storage/import";
 import { downloadFile } from "../../utils";
 
 const { useState, useRef } = Spicetify.React;
@@ -207,10 +202,7 @@ export function DataTab({ onRefresh }: Props) {
 
 	return (
 		<div>
-			<div
-				className="settings-row"
-				style={{ flexDirection: "column", alignItems: "flex-start", gap: "12px" }}
-			>
+			<div className="settings-row" style={{ flexDirection: "column", alignItems: "flex-start", gap: "12px" }}>
 				<input
 					ref={fileInputRef}
 					type="file"
@@ -233,11 +225,7 @@ export function DataTab({ onRefresh }: Props) {
 							<div className="settings-label">Import play history</div>
 							<div className="settings-sublabel">Accepts .csv or .json from a v1 export</div>
 						</div>
-						<button
-							type="button"
-							className="btn-primary"
-							onClick={() => fileInputRef.current?.click()}
-						>
+						<button type="button" className="btn-primary" onClick={() => fileInputRef.current?.click()}>
 							Import Data
 						</button>
 					</div>
@@ -248,33 +236,23 @@ export function DataTab({ onRefresh }: Props) {
 						<span className="import-progress-label">
 							Importing... {importProgress.current} / {importProgress.total}
 						</span>
-						<progress
-							className="import-progress-bar"
-							value={importProgress.current}
-							max={importProgress.total}
-						/>
+						<progress className="import-progress-bar" value={importProgress.current} max={importProgress.total} />
 					</div>
 				)}
 
 				{importPhase === "complete" && importSummary && (
 					<div className="import-result-card">
 						<div className="import-result-row">
-							<span className="import-result-count import-result-count--success">
-								{importSummary.imported}
-							</span>
+							<span className="import-result-count import-result-count--success">{importSummary.imported}</span>
 							<span className="import-result-label">imported</span>
 						</div>
 						<div className="import-result-row">
-							<span className="import-result-count import-result-count--neutral">
-								{importSummary.skipped}
-							</span>
+							<span className="import-result-count import-result-count--neutral">{importSummary.skipped}</span>
 							<span className="import-result-label">skipped as duplicates</span>
 						</div>
 						{importSummary.errors > 0 && (
 							<div className="import-result-row">
-								<span className="import-result-count import-result-count--error">
-									{importSummary.errors}
-								</span>
+								<span className="import-result-count import-result-count--error">{importSummary.errors}</span>
 								<span className="import-result-label">errors</span>
 							</div>
 						)}
@@ -340,10 +318,7 @@ export function DataTab({ onRefresh }: Props) {
 			</div>
 
 			{/* Wipe All Data */}
-			<div
-				className="settings-row"
-				style={{ flexDirection: "column", alignItems: "flex-start", gap: "12px" }}
-			>
+			<div className="settings-row" style={{ flexDirection: "column", alignItems: "flex-start", gap: "12px" }}>
 				{!confirmWipe ? (
 					<button type="button" className="btn-destructive" onClick={() => setConfirmWipe(true)}>
 						Wipe All Data

--- a/src/app/components/settings/DisplayTab.tsx
+++ b/src/app/components/settings/DisplayTab.tsx
@@ -420,6 +420,8 @@ export function DisplayTab({
 				</div>
 			)}
 
+
+
 			<div className="settings-row">
 				<div>
 					<div className="settings-label">Layout</div>

--- a/src/app/components/settings/DisplayTab.tsx
+++ b/src/app/components/settings/DisplayTab.tsx
@@ -42,11 +42,7 @@ interface LayoutSnapshot {
 	overviewOrder: { local: string[]; statsfm: string[] };
 }
 
-export function DisplayTab({
-	onPrefsChanged,
-	onRestartTour,
-	announcementDismissKey = null,
-}: DisplayTabProps) {
+export function DisplayTab({ onPrefsChanged, onRestartTour, announcementDismissKey = null }: DisplayTabProps) {
 	const [prefs, setPrefs] = useState(() => getPreferences());
 	const [layoutUndo, setLayoutUndo] = useState<LayoutSnapshot | null>(null);
 
@@ -180,9 +176,7 @@ export function DisplayTab({
 	};
 	const knownSet = new Set<string>(SECTION_IDS as readonly string[]);
 	const allowedSections = new Set(getSectionsForProvider(providerCaps).map((s) => s.id));
-	const sectionOrder = prefs.sectionOrder.filter(
-		(id) => knownSet.has(id) && allowedSections.has(id),
-	);
+	const sectionOrder = prefs.sectionOrder.filter((id) => knownSet.has(id) && allowedSections.has(id));
 
 	const sortable = useSettingsSortable({
 		order: sectionOrder,
@@ -355,8 +349,8 @@ export function DisplayTab({
 				<div>
 					<div className="settings-label">Announcement banner</div>
 					<div className="settings-sublabel">
-						Show the banner when one is available (GitHub or version splash). Turning off hides it
-						until the announcement changes or you turn this back on.
+						Show the banner when one is available (GitHub or version splash). Turning off hides it until the
+						announcement changes or you turn this back on.
 					</div>
 				</div>
 				{Toggle ? (
@@ -399,17 +393,14 @@ export function DisplayTab({
 								<>Also show streams for your current dashboard period (stats.fm top tracks).</>
 							) : (
 								<>
-									When this track has <strong>no qualifying plays</strong> in your database yet,
-									show a <strong>New play</strong> hint on the playbar (skips excluded).
+									When this track has <strong>no qualifying plays</strong> in your database yet, show a{" "}
+									<strong>New play</strong> hint on the playbar (skips excluded).
 								</>
 							)}
 						</div>
 					</div>
 					{Toggle ? (
-						<Toggle
-							value={prefs.playCountShowPeriodStreams}
-							onSelected={handlePlayCountPeriodStreams}
-						/>
+						<Toggle value={prefs.playCountShowPeriodStreams} onSelected={handlePlayCountPeriodStreams} />
 					) : (
 						<input
 							type="checkbox"
@@ -419,8 +410,6 @@ export function DisplayTab({
 					)}
 				</div>
 			)}
-
-
 
 			<div className="settings-row">
 				<div>
@@ -438,20 +427,13 @@ export function DisplayTab({
 				</button>
 			</div>
 
-			<div
-				style={{ marginTop: "4px" }}
-				data-drag-active={sortable.dragState.isDragging ? "true" : "false"}
-			>
+			<div style={{ marginTop: "4px" }} data-drag-active={sortable.dragState.isDragging ? "true" : "false"}>
 				<div className="settings-label" style={{ padding: "12px 0 4px" }}>
 					Visible sections
 				</div>
 				<div
 					className="settings-drop-line"
-					data-active={
-						sortable.dragState.isDragging && sortable.dragState.dropSlotIndex === 0
-							? "true"
-							: "false"
-					}
+					data-active={sortable.dragState.isDragging && sortable.dragState.dropSlotIndex === 0 ? "true" : "false"}
 				/>
 				{sectionOrder.map((id, idx) => {
 					const visible = !prefs.hiddenSections.includes(id);
@@ -472,10 +454,7 @@ export function DisplayTab({
 									style={sortable.getItemStyle(id)}
 								>
 									{Toggle ? (
-										<Toggle
-											value={visible}
-											onSelected={(val: boolean) => handleToggleSection(id, val)}
-										/>
+										<Toggle value={visible} onSelected={(val: boolean) => handleToggleSection(id, val)} />
 									) : (
 										<input
 											type="checkbox"
@@ -488,9 +467,7 @@ export function DisplayTab({
 							<div
 								className="settings-drop-line"
 								data-active={
-									sortable.dragState.isDragging && sortable.dragState.dropSlotIndex === idx + 1
-										? "true"
-										: "false"
+									sortable.dragState.isDragging && sortable.dragState.dropSlotIndex === idx + 1 ? "true" : "false"
 								}
 							/>
 						</Spicetify.React.Fragment>
@@ -508,9 +485,7 @@ export function DisplayTab({
 						<div className="overview-settings-hero-sub">Fixed</div>
 					</div>
 					<div className="sortable-grid sortable-grid--2x2">
-						{overviewTop.map((id) =>
-							renderSortableTile(id, OVERVIEW_CARD_LABELS, overviewTopSortable, overviewTop),
-						)}
+						{overviewTop.map((id) => renderSortableTile(id, OVERVIEW_CARD_LABELS, overviewTopSortable, overviewTop))}
 					</div>
 				</div>
 				{overviewBottom.length > 0 && (
@@ -539,9 +514,7 @@ export function DisplayTab({
 					</div>
 				)}
 				<div className="sortable-grid sortable-grid--1x3">
-					{prefs.columnOrder.map((id) =>
-						renderSortableTile(id, COLUMN_LABELS, columnSortable, prefs.columnOrder),
-					)}
+					{prefs.columnOrder.map((id) => renderSortableTile(id, COLUMN_LABELS, columnSortable, prefs.columnOrder))}
 				</div>
 			</div>
 

--- a/src/app/components/settings/ProvidersTab.tsx
+++ b/src/app/components/settings/ProvidersTab.tsx
@@ -46,9 +46,7 @@ const LASTFM_ERROR_MESSAGES: Record<string, string> = {
 
 export function ProvidersTab() {
 	const [username, setUsername] = useState("");
-	const [phase, setPhase] = useState<ConnectPhase>(() =>
-		readStatsFmConfig() ? "connected" : "idle",
-	);
+	const [phase, setPhase] = useState<ConnectPhase>(() => (readStatsFmConfig() ? "connected" : "idle"));
 	const [config, setConfig] = useState<StatsFmConfig | null>(() => readStatsFmConfig());
 	const [connectError, setConnectError] = useState<string | null>(null);
 	const [revalidating, setRevalidating] = useState(false);
@@ -67,9 +65,7 @@ export function ProvidersTab() {
 
 		const result = await validateUsername(username.trim());
 		if (!result.valid) {
-			setConnectError(
-				ERROR_MESSAGES[result.reason] ?? "Connection failed. Check the console for details.",
-			);
+			setConnectError(ERROR_MESSAGES[result.reason] ?? "Connection failed. Check the console for details.");
 			setPhase("error");
 			return;
 		}
@@ -110,9 +106,7 @@ export function ProvidersTab() {
 
 		const result = await validateUsername(config.username);
 		if (!result.valid) {
-			setRevalidateError(
-				ERROR_MESSAGES[result.reason] ?? "Validation failed. Check the console for details.",
-			);
+			setRevalidateError(ERROR_MESSAGES[result.reason] ?? "Validation failed. Check the console for details.");
 			setRevalidating(false);
 			return;
 		}
@@ -191,19 +185,13 @@ export function ProvidersTab() {
 							if (activeProviderId !== p.id) handleProviderSwitch(p.id);
 						}}
 						style={
-							p.id === "statsfm" && !hasStatsFmConfig
-								? { opacity: 0.5, pointerEvents: "none" as const }
-								: undefined
+							p.id === "statsfm" && !hasStatsFmConfig ? { opacity: 0.5, pointerEvents: "none" as const } : undefined
 						}
 					>
 						<div>
-							<div className="settings-label">
-								{p.id === "local" ? "Local Tracking" : "stats.fm"}
-							</div>
+							<div className="settings-label">{p.id === "local" ? "Local Tracking" : "stats.fm"}</div>
 							<div className="settings-sublabel">
-								{p.id === "local"
-									? "Stats tracked directly on this device"
-									: "Import stats from your stats.fm account"}
+								{p.id === "local" ? "Stats tracked directly on this device" : "Import stats from your stats.fm account"}
 							</div>
 						</div>
 					</div>
@@ -266,9 +254,7 @@ export function ProvidersTab() {
 						<span style={{ color: "var(--spice-text)", fontWeight: 700 }}>{config.username}</span>
 						<span className={`tier-badge ${tierClass}`}>{tierLabel}</span>
 					</div>
-					<div className="settings-sublabel">
-						Connected since {new Date(config.connectedAt).toLocaleDateString()}
-					</div>
+					<div className="settings-sublabel">Connected since {new Date(config.connectedAt).toLocaleDateString()}</div>
 					<div
 						style={{
 							display: "flex",

--- a/src/app/components/settings/TrackingTab.tsx
+++ b/src/app/components/settings/TrackingTab.tsx
@@ -10,9 +10,7 @@ import { EVENTS } from "../../../shared/constants/events";
 import { LS_KEYS } from "../../../shared/constants/storage-keys";
 import { SegmentedControl } from "../SegmentedControl";
 
-const THRESHOLD_STOPS = [
-	0, 5000, 10000, 15000, 20000, 25000, 30000, 35000, 40000, 45000, 50000, 55000, 60000,
-];
+const THRESHOLD_STOPS = [0, 5000, 10000, 15000, 20000, 25000, 30000, 35000, 40000, 45000, 50000, 55000, 60000];
 
 const { useState } = Spicetify.React;
 
@@ -72,11 +70,7 @@ export function TrackingTab({ onPrefsChanged }: TrackingTabProps) {
 				{Toggle ? (
 					<Toggle value={paused} onSelected={handlePause} />
 				) : (
-					<input
-						type="checkbox"
-						checked={paused}
-						onChange={(e) => handlePause(e.currentTarget.checked)}
-					/>
+					<input type="checkbox" checked={paused} onChange={(e) => handlePause(e.currentTarget.checked)} />
 				)}
 			</div>
 
@@ -89,11 +83,7 @@ export function TrackingTab({ onPrefsChanged }: TrackingTabProps) {
 				{Toggle ? (
 					<Toggle value={skipRepeats} onSelected={handleSkipRepeats} />
 				) : (
-					<input
-						type="checkbox"
-						checked={skipRepeats}
-						onChange={(e) => handleSkipRepeats(e.currentTarget.checked)}
-					/>
+					<input type="checkbox" checked={skipRepeats} onChange={(e) => handleSkipRepeats(e.currentTarget.checked)} />
 				)}
 			</div>
 
@@ -120,11 +110,7 @@ export function TrackingTab({ onPrefsChanged }: TrackingTabProps) {
 				{Toggle ? (
 					<Toggle value={logging} onSelected={handleLogging} />
 				) : (
-					<input
-						type="checkbox"
-						checked={logging}
-						onChange={(e) => handleLogging(e.currentTarget.checked)}
-					/>
+					<input type="checkbox" checked={logging} onChange={(e) => handleLogging(e.currentTarget.checked)} />
 				)}
 			</div>
 		</div>

--- a/src/app/hooks/useSettingsSortable.ts
+++ b/src/app/hooks/useSettingsSortable.ts
@@ -60,12 +60,7 @@ export function useSettingsSortable(opts: UseSettingsSortableOptions): UseSettin
 					const el = itemElsRef.current.get(ord[i]);
 					if (!el) continue;
 					const rect = el.getBoundingClientRect();
-					if (
-						pointerX >= rect.left &&
-						pointerX <= rect.right &&
-						pointerY >= rect.top &&
-						pointerY <= rect.bottom
-					) {
+					if (pointerX >= rect.left && pointerX <= rect.right && pointerY >= rect.top && pointerY <= rect.bottom) {
 						const midX = (rect.left + rect.right) / 2;
 						return pointerX < midX ? i : i + 1;
 					}

--- a/src/app/mytopspotify-charts.ts
+++ b/src/app/mytopspotify-charts.ts
@@ -5,8 +5,7 @@ const ARTISTS_URL = "https://mytopspotify.io/spotify-top-artists.json";
 
 const FETCH_HEADERS: Record<string, string> = {
 	Accept: "application/json",
-	"User-Agent":
-		"Mozilla/5.0 (compatible; ListeningStats/2.x; +https://github.com/Xndr2/listening-stats)",
+	"User-Agent": "Mozilla/5.0 (compatible; ListeningStats/2.x; +https://github.com/Xndr2/listening-stats)",
 };
 
 function formatMytopListeners(raw: string | undefined): string {

--- a/src/app/preferences.ts
+++ b/src/app/preferences.ts
@@ -14,15 +14,7 @@ export const SECTION_IDS = [
 export const COLUMN_IDS = ["top-tracks", "top-artists", "top-albums"] as const;
 
 export const OVERVIEW_CARD_IDS = {
-	local: [
-		"tracks",
-		"unique-artists",
-		"streak",
-		"new-artists",
-		"peak-hour",
-		"skip-rate",
-		"est-payout",
-	],
+	local: ["tracks", "unique-artists", "streak", "new-artists", "peak-hour", "skip-rate", "est-payout"],
 	statsfm: ["unique-artists", "new-artists", "top-genre", "est-payout"],
 } as const;
 
@@ -190,9 +182,7 @@ export function getPreferences(): Preferences {
 						? parsed.playCountShowPeriodStreams
 						: DEFAULTS.playCountShowPeriodStreams,
 				receiveBetaUpdates:
-					typeof parsed.receiveBetaUpdates === "boolean"
-						? parsed.receiveBetaUpdates
-						: DEFAULTS.receiveBetaUpdates,
+					typeof parsed.receiveBetaUpdates === "boolean" ? parsed.receiveBetaUpdates : DEFAULTS.receiveBetaUpdates,
 				showAnnouncementBanner:
 					typeof parsed.showAnnouncementBanner === "boolean"
 						? parsed.showAnnouncementBanner

--- a/src/app/preferences.ts
+++ b/src/app/preferences.ts
@@ -66,6 +66,7 @@ export interface Preferences {
 	 * track has no qualifying plays yet (skips excluded).
 	 */
 	playCountShowPeriodStreams: boolean;
+
 	activePage: string;
 	/** Include GitHub prereleases when checking for updates */
 	receiveBetaUpdates: boolean;

--- a/src/app/styles.css
+++ b/src/app/styles.css
@@ -707,7 +707,7 @@ button.announcement-banner-link-btn:hover {
 .activity-bar {
 	flex: 1;
 	background: rgba(var(--spice-rgb-button), 0.4);
-	border-radius: 2px 2px 0 0;
+	border-radius: 6px 6px 0 0;
 	min-width: 4px;
 	transition: height 0.2s ease;
 	cursor: pointer;
@@ -760,6 +760,15 @@ button.announcement-banner-link-btn:hover {
 	margin-top: 6px;
 	font-size: 12px;
 	color: rgba(var(--spice-rgb-text), 0.62);
+}
+
+.consistency-metric--accent {
+	border-color: rgba(var(--spice-rgb-button), 0.3);
+	background: rgba(var(--spice-rgb-button), 0.06);
+}
+
+.consistency-metric--accent .consistency-metric-value {
+	color: #1ed760;
 }
 
 .consistency-footer {

--- a/src/app/tour.ts
+++ b/src/app/tour.ts
@@ -90,12 +90,8 @@ export function getTourSteps(context?: TourContext): TourStep[] {
 	if (context.activePage === "world") {
 		return [BASE_TOUR_STEPS[0], BASE_TOUR_STEPS[1], ACTION_TOUR_STEPS[1]];
 	}
-	const sectionSteps = context.sectionIds
-		.map((id) => SECTION_TOUR_STEPS[id])
-		.filter((s): s is TourStep => !!s);
-	const actionSteps = context.hasShare
-		? ACTION_TOUR_STEPS
-		: ACTION_TOUR_STEPS.filter((s) => s.id !== "share");
+	const sectionSteps = context.sectionIds.map((id) => SECTION_TOUR_STEPS[id]).filter((s): s is TourStep => !!s);
+	const actionSteps = context.hasShare ? ACTION_TOUR_STEPS : ACTION_TOUR_STEPS.filter((s) => s.id !== "share");
 	return [...BASE_TOUR_STEPS, ...sectionSteps, ...actionSteps];
 }
 

--- a/src/app/utils.ts
+++ b/src/app/utils.ts
@@ -15,11 +15,7 @@ export function downloadFile(content: string, filename: string, mimeType: string
 	URL.revokeObjectURL(url);
 }
 
-export function downloadBufferAsFile(
-	buffer: ArrayBuffer,
-	filename: string,
-	mimeType = "application/zip",
-): void {
+export function downloadBufferAsFile(buffer: ArrayBuffer, filename: string, mimeType = "application/zip"): void {
 	const blob = new Blob([buffer], { type: mimeType });
 	const url = URL.createObjectURL(blob);
 	const a = document.createElement("a");

--- a/src/app/world-charts-service.ts
+++ b/src/app/world-charts-service.ts
@@ -5,12 +5,7 @@ export type {
 	WorldWindow,
 } from "../shared/types/world-charts";
 
-import type {
-	WorldChartDataSource,
-	WorldScope,
-	WorldTrack,
-	WorldWindow,
-} from "../shared/types/world-charts";
+import type { WorldChartDataSource, WorldScope, WorldTrack, WorldWindow } from "../shared/types/world-charts";
 import {
 	enrichWorldTracksWithMytopImages,
 	fetchMytopImageLookups,
@@ -194,9 +189,7 @@ function mapArtistRow(r: ChartArtistPayload): WorldTrack {
 	};
 }
 
-async function fetchChartTracks(
-	range: string,
-): Promise<Array<WorldTrack & { spotifyTrackId?: string }>> {
+async function fetchChartTracks(range: string): Promise<Array<WorldTrack & { spotifyTrackId?: string }>> {
 	const url = `${CHARTS_API}/charts/top/tracks?range=${encodeURIComponent(range)}`;
 	const res = await fetch(url, { headers: { Accept: "application/json" } });
 	if (!res.ok) throw new Error(`HTTP ${res.status}`);
@@ -219,10 +212,7 @@ export function getCharts(_scope: WorldScope, _window: WorldWindow): WorldTrack[
 	return [...WORLD_TRACKS];
 }
 
-export async function getChartsAsync(
-	_scope: WorldScope,
-	window: WorldWindow,
-): Promise<WorldChartResult<WorldTrack[]>> {
+export async function getChartsAsync(_scope: WorldScope, window: WorldWindow): Promise<WorldChartResult<WorldTrack[]>> {
 	const range = RANGE_BY_WINDOW[window] ?? "today";
 	try {
 		const raw = await fetchChartTracks(range);

--- a/src/extension/index.ts
+++ b/src/extension/index.ts
@@ -9,8 +9,8 @@ const POLL_TIMEOUT_MS = 30_000;
 	function poll() {
 		// Wait until Player.addEventListener exists
 		if (
-			!(globalThis as unknown as { Spicetify?: { Player?: { addEventListener?: unknown } } })
-				.Spicetify?.Player?.addEventListener
+			!(globalThis as unknown as { Spicetify?: { Player?: { addEventListener?: unknown } } }).Spicetify?.Player
+				?.addEventListener
 		) {
 			if (Date.now() - started > POLL_TIMEOUT_MS) {
 				console.error("[listening-stats] Spicetify init timeout: Player API not found after 30s");
@@ -22,8 +22,8 @@ const POLL_TIMEOUT_MS = 30_000;
 
 		// Wait until current track metadata is present
 		if (
-			!(globalThis as unknown as { Spicetify?: { Player?: { data?: { item?: unknown } } } })
-				.Spicetify?.Player?.data?.item
+			!(globalThis as unknown as { Spicetify?: { Player?: { data?: { item?: unknown } } } }).Spicetify?.Player?.data
+				?.item
 		) {
 			if (Date.now() - started > POLL_TIMEOUT_MS) {
 				console.warn("[listening-stats] Spicetify init timeout: Player data not loaded after 30s");

--- a/src/extension/tracker/fsm.ts
+++ b/src/extension/tracker/fsm.ts
@@ -125,9 +125,7 @@ export class TrackingFSM {
 			this._state.state = "completing";
 			const totalPlayedMs =
 				this._state.accumulatedPlayMs +
-				(this._state.isPlaying && this._state.playStartTime !== null
-					? Date.now() - this._state.playStartTime
-					: 0);
+				(this._state.isPlaying && this._state.playStartTime !== null ? Date.now() - this._state.playStartTime : 0);
 			await this._writePlayEvent(totalPlayedMs);
 		}
 
@@ -203,9 +201,7 @@ export class TrackingFSM {
 
 				const totalPlayedMs =
 					this._state.accumulatedPlayMs +
-					(this._state.isPlaying && this._state.playStartTime !== null
-						? Date.now() - this._state.playStartTime
-						: 0);
+					(this._state.isPlaying && this._state.playStartTime !== null ? Date.now() - this._state.playStartTime : 0);
 
 				// Write and re-capture async (don't await in sync handler)
 				void this._writePlayEvent(totalPlayedMs).then(() => {

--- a/src/extension/tracker/index.ts
+++ b/src/extension/tracker/index.ts
@@ -38,9 +38,7 @@ export async function initTracker(): Promise<void> {
 		if (integrity.restored) {
 			health.recordSuccess("Restored from backup after external wipe");
 		} else {
-			health.recordFailure(
-				integrity.warning ?? "External data wipe detected  -  play history lost",
-			);
+			health.recordFailure(integrity.warning ?? "External data wipe detected  -  play history lost");
 		}
 	}
 
@@ -71,14 +69,11 @@ export async function initTracker(): Promise<void> {
 	registerListeners();
 
 	// If a track is already playing at init time, capture it
-	const playerData = (globalThis as unknown as { Spicetify?: { Player?: { data?: unknown } } })
-		.Spicetify?.Player?.data;
+	const playerData = (globalThis as unknown as { Spicetify?: { Player?: { data?: unknown } } }).Spicetify?.Player?.data;
 	if (playerData && (playerData as { item?: unknown }).item) {
-		fsm
-			.handleSongChange(playerData as Parameters<TrackingFSM["handleSongChange"]>[0])
-			.catch((err) => {
-				console.warn("[listening-stats] initial song capture error:", err);
-			});
+		fsm.handleSongChange(playerData as Parameters<TrackingFSM["handleSongChange"]>[0]).catch((err) => {
+			console.warn("[listening-stats] initial song capture error:", err);
+		});
 	}
 
 	// Re-register listeners if Spotify drops them
@@ -112,11 +107,9 @@ function registerListeners(): void {
 	if (!player?.addEventListener) return;
 
 	const songChangeHandler = () => {
-		fsm
-			?.handleSongChange(player.data as Parameters<TrackingFSM["handleSongChange"]>[0])
-			.catch((err) => {
-				console.warn("[listening-stats] songchange error:", err);
-			});
+		fsm?.handleSongChange(player.data as Parameters<TrackingFSM["handleSongChange"]>[0]).catch((err) => {
+			console.warn("[listening-stats] songchange error:", err);
+		});
 	};
 
 	const playPauseHandler = () => {
@@ -125,11 +118,7 @@ function registerListeners(): void {
 	};
 
 	const progressHandler = () => {
-		fsm?.handleProgress(
-			player.getProgress?.() ?? 0,
-			player.getDuration?.() ?? 0,
-			player.getRepeat?.() ?? 0,
-		);
+		fsm?.handleProgress(player.getProgress?.() ?? 0, player.getDuration?.() ?? 0, player.getRepeat?.() ?? 0);
 	};
 
 	player.addEventListener("songchange", songChangeHandler);

--- a/src/shared/announcements/remote-announcement.ts
+++ b/src/shared/announcements/remote-announcement.ts
@@ -62,9 +62,7 @@ export function parseAnnouncementMarkdown(raw: string): ParsedRemoteAnnouncement
 		return {
 			dismissId: update.dismissId,
 			title: update.headline,
-			body:
-				rest.trim() ||
-				"Open the changelog in the app, or run the install script from Settings → About to update.",
+			body: rest.trim() || "Open the changelog in the app, or run the install script from Settings → About to update.",
 			actionLabel: "Changelog",
 			actionUrl: `${GITHUB_REPO_WEB_URL}/releases`,
 			actionOpensChangelog: true,
@@ -125,10 +123,7 @@ export async function fetchRemoteAnnouncement(): Promise<ParsedRemoteAnnouncemen
 				text = await res.text();
 			}
 			try {
-				sessionStorage.setItem(
-					SESSION_CACHE_KEY,
-					JSON.stringify({ t: Date.now(), text: text ?? "" }),
-				);
+				sessionStorage.setItem(SESSION_CACHE_KEY, JSON.stringify({ t: Date.now(), text: text ?? "" }));
 			} catch {
 				/* ignore */
 			}

--- a/src/shared/api/cosmos-async.ts
+++ b/src/shared/api/cosmos-async.ts
@@ -21,8 +21,7 @@ export async function cosmosGet<T>(path: string): Promise<Result<T, ApiError>> {
 		const response = await Spicetify.CosmosAsync.request("GET", path);
 
 		if (response.status === 429) {
-			const retryAfterRaw =
-				response.headers?.["retry-after"] ?? response.headers?.["Retry-After"] ?? "5";
+			const retryAfterRaw = response.headers?.["retry-after"] ?? response.headers?.["Retry-After"] ?? "5";
 			const retryAfter = Number(retryAfterRaw) || 5;
 			circuitBreaker.recordFailure(retryAfter);
 			return { ok: false, error: { type: "rate_limited", retryAfter } };

--- a/src/shared/api/lastfm-client.ts
+++ b/src/shared/api/lastfm-client.ts
@@ -9,9 +9,7 @@ const COUNTRY_MAP: Record<string, string> = {
 	jp: "japan",
 };
 
-export type LastfmResult =
-	| { ok: true; data: WorldTrack[] }
-	| { ok: false; status: number; message: string };
+export type LastfmResult = { ok: true; data: WorldTrack[] } | { ok: false; status: number; message: string };
 
 interface LastfmRawTrack {
 	name: string;
@@ -94,11 +92,7 @@ async function fetchChart(
 	}
 }
 
-export async function lastfmGetCharts(
-	scope: WorldScope,
-	_window: WorldWindow,
-	apiKey: string,
-): Promise<LastfmResult> {
+export async function lastfmGetCharts(scope: WorldScope, _window: WorldWindow, apiKey: string): Promise<LastfmResult> {
 	return fetchChart(scope, apiKey, "chart.gettoptracks", "geo.gettoptracks", (json) => {
 		const raw = json?.tracks as { track?: unknown } | undefined;
 		return mapTracks(Array.isArray(raw?.track) ? raw.track : []);
@@ -132,9 +126,7 @@ export function classifyLastfmError(status: number, message: string, resetAt?: n
 	return { variant: "Unknown", message, retryable: true };
 }
 
-export type LastfmValidation =
-	| { valid: true }
-	| { valid: false; reason: "invalid_key" | "network" };
+export type LastfmValidation = { valid: true } | { valid: false; reason: "invalid_key" | "network" };
 
 export async function validateLastfmKey(apiKey: string): Promise<LastfmValidation> {
 	const result = await lastfmGetCharts("world", "today", apiKey);

--- a/src/shared/api/statsfm-client.ts
+++ b/src/shared/api/statsfm-client.ts
@@ -42,10 +42,7 @@ function publishSfmHealth(payload: StatsFmHealthPayload): void {
 	window.dispatchEvent(new CustomEvent(EVENTS.STATSFM_HEALTH_CHANGED, { detail: payload }));
 }
 
-export async function sfmGet<T>(
-	path: string,
-	params?: Record<string, string>,
-): Promise<SfmResult<T>> {
+export async function sfmGet<T>(path: string, params?: Record<string, string>): Promise<SfmResult<T>> {
 	if (sfmCircuitBreaker.isOpen()) {
 		publishSfmHealth({
 			lastFetchAt: Date.now(),

--- a/src/shared/api/statsfm-track-plays.ts
+++ b/src/shared/api/statsfm-track-plays.ts
@@ -58,10 +58,7 @@ export async function fetchStatsFmTopTrackStreams(
 	return null;
 }
 
-export async function fetchStatsFmLifetimeTrackStreams(
-	username: string,
-	trackUri: string,
-): Promise<number | null> {
+export async function fetchStatsFmLifetimeTrackStreams(username: string, trackUri: string): Promise<number | null> {
 	return fetchStatsFmTopTrackStreams(username, trackUri, "lifetime");
 }
 

--- a/src/shared/share/hydrate-share-assets.ts
+++ b/src/shared/share/hydrate-share-assets.ts
@@ -138,9 +138,7 @@ async function hydrateAlbumArtForTracks(tracks: TopTrack[]): Promise<void> {
 }
 
 async function hydrateAlbumArtFromTracksApi(tracks: TopTrack[]): Promise<void> {
-	const need = tracks.filter(
-		(t) => (!t.albumArt || !String(t.albumArt).trim()) && spotifyTrackId(t.trackUri),
-	);
+	const need = tracks.filter((t) => (!t.albumArt || !String(t.albumArt).trim()) && spotifyTrackId(t.trackUri));
 	if (need.length === 0) return;
 
 	const idToTracks = new Map<string, TopTrack[]>();

--- a/src/shared/stats/artist-enrichment.ts
+++ b/src/shared/stats/artist-enrichment.ts
@@ -45,9 +45,7 @@ export async function enrichArtists(artistUris: string[]): Promise<void> {
 	for (let i = 0; i < unenriched.length; i += BATCH_SIZE) {
 		const batch = unenriched.slice(i, i + BATCH_SIZE);
 		const ids = batch.map((uri) => uri.replace(/^spotify:artist:/i, "")).join(",");
-		const result = await cosmosGet<SpotifyArtistsResponse>(
-			`https://api.spotify.com/v1/artists?ids=${ids}`,
-		);
+		const result = await cosmosGet<SpotifyArtistsResponse>(`https://api.spotify.com/v1/artists?ids=${ids}`);
 
 		if (!result.ok) continue;
 

--- a/src/shared/stats/local-provider.ts
+++ b/src/shared/stats/local-provider.ts
@@ -1,14 +1,6 @@
 import { db } from "../storage/db";
 import type { PlayEvent } from "../types/play-event";
-import type {
-	Period,
-	RecentPlay,
-	StatsResult,
-	TopAlbum,
-	TopArtist,
-	TopGenre,
-	TopTrack,
-} from "../types/stats";
+import type { Period, RecentPlay, StatsResult, TopAlbum, TopArtist, TopGenre, TopTrack } from "../types/stats";
 import { normalizeSpotifyImageUrl } from "../util/spotify-image-url";
 import { enrichArtists, isSpotifyArtistUri } from "./artist-enrichment";
 import { getAdjacentPeriod, getPriorPeriodBoundaries, LOCAL_PERIODS } from "./periods";
@@ -170,10 +162,7 @@ export class LocalProvider implements StatsProvider {
 				durationMs: number;
 			}
 		>();
-		const artistMap = new Map<
-			string,
-			{ name: string; uri: string; count: number; durationMs: number }
-		>();
+		const artistMap = new Map<string, { name: string; uri: string; count: number; durationMs: number }>();
 		const albumMap = new Map<
 			string,
 			{
@@ -278,8 +267,7 @@ export class LocalProvider implements StatsProvider {
 
 		const totalDuration = playEvents.reduce((sum, e) => sum + e.playedMs, 0);
 
-		const listeningDays =
-			playEvents.length > 0 ? new Set(playEvents.map((e) => toLocalDateKey(e.startedAt))).size : 0;
+		const listeningDays = playEvents.length > 0 ? new Set(playEvents.map((e) => toLocalDateKey(e.startedAt))).size : 0;
 
 		// Hourly distribution (24-element array, index = local hour)
 		const hourlyDistribution = new Array(24).fill(0) as number[];
@@ -289,8 +277,7 @@ export class LocalProvider implements StatsProvider {
 		}
 
 		// Peak hour: index of max value, or 0 if no plays
-		const peakHour =
-			playEvents.length > 0 ? hourlyDistribution.indexOf(Math.max(...hourlyDistribution)) : 0;
+		const peakHour = playEvents.length > 0 ? hourlyDistribution.indexOf(Math.max(...hourlyDistribution)) : 0;
 
 		// Weekday distribution (7-element, Mon=0 through Sun=6)
 		const weekdayDistribution = new Array(7).fill(0) as number[];
@@ -299,8 +286,7 @@ export class LocalProvider implements StatsProvider {
 			const idx = jsDay === 0 ? 6 : jsDay - 1; // -> 0=Mon..6=Sun
 			weekdayDistribution[idx]++;
 		}
-		const peakWeekday =
-			playEvents.length > 0 ? weekdayDistribution.indexOf(Math.max(...weekdayDistribution)) : 0;
+		const peakWeekday = playEvents.length > 0 ? weekdayDistribution.indexOf(Math.max(...weekdayDistribution)) : 0;
 
 		// Daily play counts for heatmap (53 weeks lookback)
 		const dailyCountMap = new Map<string, number>();
@@ -336,10 +322,7 @@ export class LocalProvider implements StatsProvider {
 			const enriched = enrichedMap.get(ta.artistUri);
 			if (enriched) {
 				ta.genres = enriched.genres;
-				ta.imageUrl =
-					normalizeSpotifyImageUrl(enriched.imageUrl ?? undefined) ??
-					enriched.imageUrl ??
-					undefined;
+				ta.imageUrl = normalizeSpotifyImageUrl(enriched.imageUrl ?? undefined) ?? enriched.imageUrl ?? undefined;
 			}
 		}
 

--- a/src/shared/stats/periods.ts
+++ b/src/shared/stats/periods.ts
@@ -11,24 +11,8 @@ function getThisWeekBoundaries(): PeriodBoundaries {
 	const now = new Date();
 	const dayOfWeek = now.getDay(); // 0=Sun, 1=Mon ... 6=Sat
 	const daysFromMonday = (dayOfWeek + 6) % 7; // Mon=0, Tue=1, ..., Sun=6 (ISO 8601)
-	const monday = new Date(
-		now.getFullYear(),
-		now.getMonth(),
-		now.getDate() - daysFromMonday,
-		0,
-		0,
-		0,
-		0,
-	);
-	const nextMonday = new Date(
-		monday.getFullYear(),
-		monday.getMonth(),
-		monday.getDate() + 7,
-		0,
-		0,
-		0,
-		0,
-	);
+	const monday = new Date(now.getFullYear(), now.getMonth(), now.getDate() - daysFromMonday, 0, 0, 0, 0);
+	const nextMonday = new Date(monday.getFullYear(), monday.getMonth(), monday.getDate() + 7, 0, 0, 0, 0);
 	return { start: monday.getTime(), end: nextMonday.getTime() };
 }
 

--- a/src/shared/stats/statsfm-provider.ts
+++ b/src/shared/stats/statsfm-provider.ts
@@ -1,21 +1,7 @@
-import {
-	type SfmResult,
-	type StatsFmConfig,
-	sfmCircuitBreaker,
-	sfmGet,
-	validateUsername,
-} from "../api/statsfm-client";
+import { type SfmResult, type StatsFmConfig, sfmCircuitBreaker, sfmGet, validateUsername } from "../api/statsfm-client";
 import { LS_KEYS } from "../constants/storage-keys";
 import { classifyStatsFmError, StatsFmError } from "../errors";
-import type {
-	Period,
-	RecentPlay,
-	StatsResult,
-	TopAlbum,
-	TopArtist,
-	TopGenre,
-	TopTrack,
-} from "../types/stats";
+import type { Period, RecentPlay, StatsResult, TopAlbum, TopArtist, TopGenre, TopTrack } from "../types/stats";
 import type {
 	SfmDateStats,
 	SfmPerDayStats,
@@ -54,7 +40,7 @@ function computeStreakFromDays(days: Record<string, { count: number; durationMs:
 	if (dateSet.size === 0) return 0;
 
 	const now = new Date();
-	let cursor = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+	const cursor = new Date(now.getFullYear(), now.getMonth(), now.getDate());
 	const todayKey = toLocalYmd(cursor.toISOString());
 
 	if (!dateSet.has(todayKey)) {
@@ -89,9 +75,7 @@ function extractData<T>(result: PromiseSettledResult<SfmResult<T>>): T | null {
 	return null;
 }
 
-function extractFailure(
-	result: PromiseSettledResult<SfmResult<unknown>>,
-): { status: number; message: string } | null {
+function extractFailure(result: PromiseSettledResult<SfmResult<unknown>>): { status: number; message: string } | null {
 	if (result.status === "fulfilled" && !result.value.ok) {
 		return { status: result.value.status, message: result.value.message };
 	}
@@ -114,10 +98,7 @@ function genresFromArtists(artists: SfmTopArtist[]): TopGenre[] {
 }
 
 /** Prefer stats.fm `/top/genres` when the API returns rows (works even when artist.genres[] is empty). */
-function topGenresFromApiOrArtists(
-	apiRows: SfmTopGenre[] | null | undefined,
-	artists: SfmTopArtist[],
-): TopGenre[] {
+function topGenresFromApiOrArtists(apiRows: SfmTopGenre[] | null | undefined, artists: SfmTopArtist[]): TopGenre[] {
 	const rows = apiRows ?? [];
 	if (rows.length > 0) {
 		return [...rows]
@@ -242,35 +223,26 @@ export class StatsFmProvider implements StatsProvider {
 				})
 			: Promise.resolve({ ok: false, status: 0, message: "skipped" } as SfmResult<SfmTopArtist[]>);
 
-		const [
-			tracksRes,
-			artistsRes,
-			genresRes,
-			statsRes,
-			recentRes,
-			albumsRes,
-			perDayRes,
-			datesRes,
-			priorArtistsRes,
-		] = await Promise.allSettled([
-			sfmGet<SfmTopTrack[]>(`/users/${username}/top/tracks`, rangeParams),
-			sfmGet<SfmTopArtist[]>(`/users/${username}/top/artists`, rangeParams),
-			sfmGet<SfmTopGenre[]>(`/users/${username}/top/genres`, rangeParams),
-			sfmGet<SfmStreamStats>(`/users/${username}/streams/stats`, rangeParams),
-			sfmGet<SfmRecentStream[]>(`/users/${username}/streams/recent`, { limit: "12" }),
-			isPlus
-				? sfmGet<SfmTopAlbum[]>(`/users/${username}/top/albums`, rangeParams)
-				: Promise.resolve({ ok: false, status: 0, message: "skipped" } as SfmResult<SfmTopAlbum[]>),
-			sfmGet<SfmPerDayStats>(`/users/${username}/streams/stats/per-day`, {
-				range: "lifetime",
-				timeZone,
-			}),
-			sfmGet<SfmDateStats>(`/users/${username}/streams/stats/dates`, {
-				range,
-				timeZone,
-			}),
-			priorPromise,
-		]);
+		const [tracksRes, artistsRes, genresRes, statsRes, recentRes, albumsRes, perDayRes, datesRes, priorArtistsRes] =
+			await Promise.allSettled([
+				sfmGet<SfmTopTrack[]>(`/users/${username}/top/tracks`, rangeParams),
+				sfmGet<SfmTopArtist[]>(`/users/${username}/top/artists`, rangeParams),
+				sfmGet<SfmTopGenre[]>(`/users/${username}/top/genres`, rangeParams),
+				sfmGet<SfmStreamStats>(`/users/${username}/streams/stats`, rangeParams),
+				sfmGet<SfmRecentStream[]>(`/users/${username}/streams/recent`, { limit: "12" }),
+				isPlus
+					? sfmGet<SfmTopAlbum[]>(`/users/${username}/top/albums`, rangeParams)
+					: Promise.resolve({ ok: false, status: 0, message: "skipped" } as SfmResult<SfmTopAlbum[]>),
+				sfmGet<SfmPerDayStats>(`/users/${username}/streams/stats/per-day`, {
+					range: "lifetime",
+					timeZone,
+				}),
+				sfmGet<SfmDateStats>(`/users/${username}/streams/stats/dates`, {
+					range,
+					timeZone,
+				}),
+				priorPromise,
+			]);
 
 		const tracksErr = extractFailure(tracksRes);
 		const artistsErr = extractFailure(artistsRes);
@@ -294,9 +266,7 @@ export class StatsFmProvider implements StatsProvider {
 			);
 			if (priorArtists.length > 0) {
 				const priorIds = new Set(
-					priorArtists
-						.map((a) => a.artist.externalIds?.spotify?.[0])
-						.filter((s): s is string => !!s),
+					priorArtists.map((a) => a.artist.externalIds?.spotify?.[0]).filter((s): s is string => !!s),
 				);
 				let count = 0;
 				for (const id of currentIds) {
@@ -345,10 +315,7 @@ export class StatsFmProvider implements StatsProvider {
 				if (hr >= 0 && hr < 24) hourlyDistribution[hr] = val.count;
 			}
 		}
-		const peakHour = hourlyDistribution.reduce(
-			(maxIdx, val, idx, arr) => (val > arr[maxIdx] ? idx : maxIdx),
-			0,
-		);
+		const peakHour = hourlyDistribution.reduce((maxIdx, val, idx, arr) => (val > arr[maxIdx] ? idx : maxIdx), 0);
 
 		// weekdayDistribution: 7-element array, index 0=Monday through 6=Sunday
 		// API weekDays keys: 1=Monday through 7=Sunday -> subtract 1 for zero-indexed array
@@ -356,8 +323,7 @@ export class StatsFmProvider implements StatsProvider {
 		let peakWeekday: number | undefined;
 		const hasDateData =
 			dateItems != null &&
-			(Object.keys(dateItems.hours ?? {}).length > 0 ||
-				Object.keys(dateItems.weekDays ?? {}).length > 0);
+			(Object.keys(dateItems.hours ?? {}).length > 0 || Object.keys(dateItems.weekDays ?? {}).length > 0);
 
 		if (hasDateData && dateItems?.weekDays) {
 			weekdayDistribution = new Array(7).fill(0) as number[];
@@ -365,10 +331,7 @@ export class StatsFmProvider implements StatsProvider {
 				const idx = Number(key) - 1; // 1-7 -> 0-6
 				if (idx >= 0 && idx < 7) weekdayDistribution[idx] = val.count;
 			}
-			peakWeekday = weekdayDistribution.reduce(
-				(maxIdx, val, idx, arr) => (val > arr[maxIdx] ? idx : maxIdx),
-				0,
-			);
+			peakWeekday = weekdayDistribution.reduce((maxIdx, val, idx, arr) => (val > arr[maxIdx] ? idx : maxIdx), 0);
 		}
 
 		// Map tracks
@@ -392,9 +355,7 @@ export class StatsFmProvider implements StatsProvider {
 		// Genres from stats.fm artist payload (no extra Spotify batch here)
 		const topArtists: TopArtist[] = artists.map((ta) => ({
 			rank: ta.position,
-			artistUri:
-				prefixUri(ta.artist.externalIds?.spotify?.[0], "artist") ??
-				`listening-stats:artist:${ta.artist.name}`,
+			artistUri: prefixUri(ta.artist.externalIds?.spotify?.[0], "artist") ?? `listening-stats:artist:${ta.artist.name}`,
 			artistName: ta.artist.name,
 			count: ta.streams,
 			durationMs: ta.playedMs ?? 0,
@@ -579,9 +540,7 @@ export class StatsFmProvider implements StatsProvider {
 			);
 			if (priorArtists.length > 0) {
 				const priorIds = new Set(
-					priorArtists
-						.map((a) => a.artist.externalIds?.spotify?.[0])
-						.filter((s): s is string => !!s),
+					priorArtists.map((a) => a.artist.externalIds?.spotify?.[0]).filter((s): s is string => !!s),
 				);
 				let count = 0;
 				for (const id of currentIds) {
@@ -624,8 +583,7 @@ export class StatsFmProvider implements StatsProvider {
 				topArtists = artists.map((ta) => ({
 					rank: ta.position,
 					artistUri:
-						prefixUri(ta.artist.externalIds?.spotify?.[0], "artist") ??
-						`listening-stats:artist:${ta.artist.name}`,
+						prefixUri(ta.artist.externalIds?.spotify?.[0], "artist") ?? `listening-stats:artist:${ta.artist.name}`,
 					artistName: ta.artist.name,
 					count: ta.streams,
 					durationMs: ta.playedMs ?? 0,
@@ -657,9 +615,7 @@ export class StatsFmProvider implements StatsProvider {
 			}),
 			perDayPromise.then((res) => {
 				perDayData = res.ok ? res.data : null;
-				listeningDays = perDayData?.days
-					? Object.values(perDayData.days).filter((d) => d.count > 0).length
-					: undefined;
+				listeningDays = perDayData?.days ? Object.values(perDayData.days).filter((d) => d.count > 0).length : undefined;
 				streak = perDayData?.days ? computeStreakFromDays(perDayData.days) : 0;
 				dailyPlayCounts = perDayData?.days
 					? Object.entries(perDayData.days)
@@ -700,17 +656,13 @@ export class StatsFmProvider implements StatsProvider {
 				if (hr >= 0 && hr < 24) hourlyDistribution[hr] = val.count;
 			}
 		}
-		const peakHour = hourlyDistribution.reduce(
-			(maxIdx, val, idx, arr) => (val > arr[maxIdx] ? idx : maxIdx),
-			0,
-		);
+		const peakHour = hourlyDistribution.reduce((maxIdx, val, idx, arr) => (val > arr[maxIdx] ? idx : maxIdx), 0);
 
 		let weekdayDistribution: number[] | undefined;
 		let peakWeekday: number | undefined;
 		const hasDateData =
 			dateItems != null &&
-			(Object.keys(dateItems.hours ?? {}).length > 0 ||
-				Object.keys(dateItems.weekDays ?? {}).length > 0);
+			(Object.keys(dateItems.hours ?? {}).length > 0 || Object.keys(dateItems.weekDays ?? {}).length > 0);
 
 		if (hasDateData && dateItems?.weekDays) {
 			weekdayDistribution = new Array(7).fill(0) as number[];
@@ -718,10 +670,7 @@ export class StatsFmProvider implements StatsProvider {
 				const idx = Number(k) - 1;
 				if (idx >= 0 && idx < 7) weekdayDistribution[idx] = val.count;
 			}
-			peakWeekday = weekdayDistribution.reduce(
-				(maxIdx, val, idx, arr) => (val > arr[maxIdx] ? idx : maxIdx),
-				0,
-			);
+			peakWeekday = weekdayDistribution.reduce((maxIdx, val, idx, arr) => (val > arr[maxIdx] ? idx : maxIdx), 0);
 		}
 
 		if (datesFailure) {

--- a/src/shared/stats/statsfm-provider.ts
+++ b/src/shared/stats/statsfm-provider.ts
@@ -34,6 +34,44 @@ import { statsCache } from "./stats-cache";
 const CACHE_KEY_PREFIX = "statsfm";
 const TWENTY_FOUR_HOURS = 24 * 60 * 60 * 1000;
 
+/**
+ * Normalize an ISO date string to local YYYY-MM-DD for reliable date-key comparison.
+ * Falls back to slicing the first 10 characters if the Date constructor fails.
+ */
+function toLocalYmd(dateStr: string): string {
+	const d = new Date(dateStr);
+	if (!Number.isFinite(d.getTime())) return dateStr.slice(0, 10);
+	return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+}
+
+function computeStreakFromDays(days: Record<string, { count: number; durationMs: number }>): number {
+	const dateSet = new Set(
+		Object.entries(days)
+			.filter(([, d]) => d.count > 0)
+			.map(([k]) => toLocalYmd(k))
+			.filter((s) => s.length === 10),
+	);
+	if (dateSet.size === 0) return 0;
+
+	const now = new Date();
+	let cursor = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+	const todayKey = toLocalYmd(cursor.toISOString());
+
+	if (!dateSet.has(todayKey)) {
+		cursor.setDate(cursor.getDate() - 1);
+		if (!dateSet.has(toLocalYmd(cursor.toISOString()))) {
+			return 0;
+		}
+	}
+
+	let streak = 0;
+	while (dateSet.has(toLocalYmd(cursor.toISOString()))) {
+		streak++;
+		cursor.setDate(cursor.getDate() - 1);
+	}
+	return streak;
+}
+
 function prefixUri(id: string | undefined, type: "track" | "artist" | "album"): string | undefined {
 	if (!id) return undefined;
 	if (id.startsWith("spotify:")) return id;
@@ -148,7 +186,7 @@ export class StatsFmProvider implements StatsProvider {
 			name: "stats.fm",
 			description: "Stats from stats.fm",
 			capabilities: {
-				hasActivityData: false,
+				hasActivityData: true,
 				hasConsistencyData: true,
 				hasGenreData: true,
 				hasStreakData: false,
@@ -227,7 +265,7 @@ export class StatsFmProvider implements StatsProvider {
 				range: "lifetime",
 				timeZone,
 			}),
-			sfmGet<{ items: SfmDateStats }>(`/users/${username}/streams/stats/dates`, {
+			sfmGet<SfmDateStats>(`/users/${username}/streams/stats/dates`, {
 				range,
 				timeZone,
 			}),
@@ -277,10 +315,10 @@ export class StatsFmProvider implements StatsProvider {
 		const listeningDays = perDayData?.days
 			? Object.values(perDayData.days).filter((d) => d.count > 0).length
 			: undefined;
-
+		const streak = perDayData?.days ? computeStreakFromDays(perDayData.days) : 0;
 		const dailyPlayCounts = perDayData?.days
 			? Object.entries(perDayData.days)
-					.map(([date, d]) => ({ date, count: d.count }))
+					.map(([date, d]) => ({ date: toLocalYmd(date), count: d.count }))
 					.sort((a, b) => a.date.localeCompare(b.date))
 			: undefined;
 
@@ -297,8 +335,7 @@ export class StatsFmProvider implements StatsProvider {
 			if (sum > 0) priorPeriodTotalDuration = sum;
 		}
 
-		const datesData = extractData<{ items: SfmDateStats }>(datesRes);
-		const dateItems = datesData?.items;
+		const dateItems = extractData<SfmDateStats>(datesRes);
 
 		// hourlyDistribution: 24-element array from hours map (keys 0-23)
 		const hourlyDistribution = new Array(24).fill(0) as number[];
@@ -406,7 +443,7 @@ export class StatsFmProvider implements StatsProvider {
 			skipRate: 0,
 			uniqueTrackCount: streamStats?.cardinality.tracks ?? 0,
 			uniqueArtistCount: streamStats?.cardinality.artists ?? 0,
-			// stats.fm payload has no streak field
+			streak,
 			listeningDays,
 			weekdayDistribution,
 			peakWeekday,
@@ -475,7 +512,7 @@ export class StatsFmProvider implements StatsProvider {
 			range: "lifetime",
 			timeZone,
 		});
-		const datesPromise = sfmGet<{ items: SfmDateStats }>(`/users/${username}/streams/stats/dates`, {
+		const datesPromise = sfmGet<SfmDateStats>(`/users/${username}/streams/stats/dates`, {
 			range,
 			timeZone,
 		});
@@ -518,6 +555,7 @@ export class StatsFmProvider implements StatsProvider {
 		let topArtists: TopArtist[] = [];
 		let topAlbums: TopAlbum[] = [];
 		let topGenres: TopGenre[] = [];
+		let streak: number | undefined;
 		let listeningDays: number | undefined;
 		let dailyPlayCounts: Array<{ date: string; count: number }> | undefined;
 		let newArtistCount: number | undefined;
@@ -622,9 +660,10 @@ export class StatsFmProvider implements StatsProvider {
 				listeningDays = perDayData?.days
 					? Object.values(perDayData.days).filter((d) => d.count > 0).length
 					: undefined;
+				streak = perDayData?.days ? computeStreakFromDays(perDayData.days) : 0;
 				dailyPlayCounts = perDayData?.days
 					? Object.entries(perDayData.days)
-							.map(([date, d]) => ({ date, count: d.count }))
+							.map(([date, d]) => ({ date: toLocalYmd(date), count: d.count }))
 							.sort((a, b) => a.date.localeCompare(b.date))
 					: undefined;
 
@@ -638,7 +677,7 @@ export class StatsFmProvider implements StatsProvider {
 					}
 					if (sum > 0) priorPeriodTotalDuration = sum;
 				}
-				onWave({ listeningDays, dailyPlayCounts, priorPeriodTotalDuration }, 2);
+				onWave({ streak, listeningDays, dailyPlayCounts, priorPeriodTotalDuration }, 2);
 			}),
 			priorPromise.then((res) => {
 				priorArtists = res.ok ? res.data : [];
@@ -652,8 +691,7 @@ export class StatsFmProvider implements StatsProvider {
 		// ── Wave 3: activity (hourly/weekday distributions) ──
 		const [datesRes] = await Promise.allSettled([datesPromise]);
 		const datesFailure = extractFailure(datesRes);
-		const datesData = extractData<{ items: SfmDateStats }>(datesRes);
-		const dateItems = datesData?.items;
+		const dateItems = extractData<SfmDateStats>(datesRes);
 
 		const hourlyDistribution = new Array(24).fill(0) as number[];
 		if (dateItems?.hours) {
@@ -723,6 +761,7 @@ export class StatsFmProvider implements StatsProvider {
 			skipRate: 0,
 			uniqueTrackCount: streamStats?.cardinality.tracks ?? 0,
 			uniqueArtistCount: streamStats?.cardinality.artists ?? 0,
+			streak,
 			listeningDays,
 			weekdayDistribution,
 			peakWeekday,

--- a/src/shared/storage/import.ts
+++ b/src/shared/storage/import.ts
@@ -110,9 +110,7 @@ export async function parseV1Csv(text: string): Promise<ParseResult> {
 				'Import failed: this is a stats summary CSV, not a raw history export. Use "Raw History (CSV)" in v1 to get importable data.',
 			);
 		}
-		throw new Error(
-			`Import failed: unrecognized CSV format (expected v1 export). Got: "${header.slice(0, 60)}"`,
-		);
+		throw new Error(`Import failed: unrecognized CSV format (expected v1 export). Got: "${header.slice(0, 60)}"`);
 	}
 
 	const events: Omit<PlayEvent, "id">[] = [];
@@ -207,11 +205,7 @@ export async function parseJsonEvents(text: string): Promise<ParseResult> {
 
 	if (!Array.isArray(parsed)) {
 		// Detect StatsResult-shaped objects specifically
-		if (
-			typeof parsed === "object" &&
-			parsed !== null &&
-			"topTracks" in (parsed as Record<string, unknown>)
-		) {
+		if (typeof parsed === "object" && parsed !== null && "topTracks" in (parsed as Record<string, unknown>)) {
 			throw new Error("Import failed: JSON must be a raw play events array, not a stats export");
 		}
 		throw new Error("Import failed: JSON must be a raw play events array, not a stats export");

--- a/src/shared/types/spicetify.d.ts
+++ b/src/shared/types/spicetify.d.ts
@@ -88,11 +88,6 @@ declare namespace Spicetify {
 		function post(url: string, body?: Body, headers?: Record<string, string>): Promise<unknown>;
 		function put(url: string, body?: Body, headers?: Record<string, string>): Promise<unknown>;
 		function del(url: string, body?: Body, headers?: Record<string, string>): Promise<unknown>;
-		function request(
-			method: Method,
-			url: string,
-			body?: Body,
-			headers?: Record<string, string>,
-		): Promise<Response>;
+		function request(method: Method, url: string, body?: Body, headers?: Record<string, string>): Promise<Response>;
 	}
 }

--- a/src/shared/update/markdown-lite.ts
+++ b/src/shared/update/markdown-lite.ts
@@ -54,9 +54,5 @@ export function markdownLiteToHtml(md: string): string {
 }
 
 function escapeHtml(s: string): string {
-	return s
-		.replace(/&/g, "&amp;")
-		.replace(/</g, "&lt;")
-		.replace(/>/g, "&gt;")
-		.replace(/"/g, "&quot;");
+	return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
 }

--- a/src/shared/update/release-info.ts
+++ b/src/shared/update/release-info.ts
@@ -1,8 +1,4 @@
-import {
-	GITHUB_API_REPO_BASE,
-	GITHUB_DIST_META_URL,
-	JSDELIVR_DIST_META_URL,
-} from "../constants/github-repo";
+import { GITHUB_API_REPO_BASE, GITHUB_DIST_META_URL, JSDELIVR_DIST_META_URL } from "../constants/github-repo";
 
 export interface ResolvedRelease {
 	tag: string;
@@ -65,9 +61,7 @@ function firstReleaseWithZip(list: ReleasePayload[] | null): ReleasePayload | un
  * - **Beta (Prereleases on):** Newest GitHub release that ships `listening-stats.zip` (includes prereleases),
  *   then fallbacks above if needed.
  */
-export async function resolvePublishedRelease(
-	receiveBetaUpdates: boolean,
-): Promise<ResolvedRelease | null> {
+export async function resolvePublishedRelease(receiveBetaUpdates: boolean): Promise<ResolvedRelease | null> {
 	if (receiveBetaUpdates) {
 		const list = await fetchGitHubJson<ReleasePayload[]>("/releases?per_page=15");
 		const picked = firstReleaseWithZip(list ?? null);
@@ -80,9 +74,7 @@ export async function resolvePublishedRelease(
 		}
 	}
 
-	const latest = await fetchGitHubJson<{ tag_name?: string; prerelease?: boolean }>(
-		"/releases/latest",
-	);
+	const latest = await fetchGitHubJson<{ tag_name?: string; prerelease?: boolean }>("/releases/latest");
 	if (latest?.tag_name) {
 		return {
 			tag: latest.tag_name,

--- a/src/shared/update/update-check.ts
+++ b/src/shared/update/update-check.ts
@@ -18,10 +18,7 @@ export function compareVersions(localVersion: string, remoteVersion: string): bo
 	return semver.gt(b, a);
 }
 
-export async function checkForAppUpdate(
-	localVersion: string,
-	receiveBetaUpdates: boolean,
-): Promise<UpdateCheckResult> {
+export async function checkForAppUpdate(localVersion: string, receiveBetaUpdates: boolean): Promise<UpdateCheckResult> {
 	const resolved = await resolvePublishedRelease(receiveBetaUpdates);
 	if (!resolved) {
 		return {

--- a/src/test/activity-section.test.tsx
+++ b/src/test/activity-section.test.tsx
@@ -21,13 +21,13 @@ const baseProps = {
 };
 
 describe("ActivitySection tab UI", () => {
-	it("renders 3 tab buttons: By hour, By weekday, By day", () => {
+	it("renders 3 tab buttons: By hour, By week, By month", () => {
 		const { container } = render(<ActivitySection {...baseProps} />);
 		const tabs = container.querySelectorAll(".activity-tab");
-		expect(tabs.length).toBe(3);
+		expect(tabs).toHaveLength(3);
 		expect(tabs[0].textContent).toBe("By hour");
-		expect(tabs[1].textContent).toBe("By weekday");
-		expect(tabs[2].textContent).toBe("By day");
+		expect(tabs[1].textContent).toBe("By week");
+		expect(tabs[2].textContent).toBe("By month");
 	});
 
 	it("defaults to 'By hour' tab active", () => {
@@ -43,20 +43,19 @@ describe("ActivitySection tab UI", () => {
 		expect(container.querySelector(".section-title")?.textContent).toBe("Activity");
 	});
 
-	it("clicking 'By weekday' tab switches view and marks tab active", () => {
+	it("clicking 'By week' tab switches view and marks tab active", () => {
 		const { container } = render(<ActivitySection {...baseProps} />);
 		const tabs = container.querySelectorAll(".activity-tab");
 		fireEvent.click(tabs[1]);
 		expect(tabs[1].classList.contains("active")).toBe(true);
 		expect(tabs[0].classList.contains("active")).toBe(false);
-		expect(container.querySelector(".weekday-chart")).not.toBeNull();
+		expect(tabs[2].classList.contains("active")).toBe(false);
 	});
 
-	it("clicking 'By day' tab shows heatmap", () => {
+	it("clicking 'By month' tab shows heatmap", () => {
 		const { container } = render(<ActivitySection {...baseProps} />);
 		const tabs = container.querySelectorAll(".activity-tab");
 		fireEvent.click(tabs[2]);
-		expect(tabs[2].classList.contains("active")).toBe(true);
 		expect(container.querySelector(".heatmap-grid")).not.toBeNull();
 	});
 
@@ -79,7 +78,7 @@ describe("ActivitySection tab persistence", () => {
 		localStorage.setItem(LS_KEYS.PREFERENCES, JSON.stringify({ activityTab: "day" }));
 		const { container } = render(<ActivitySection {...baseProps} />);
 		const active = container.querySelector(".activity-tab.active");
-		expect(active?.textContent).toBe("By day");
+		expect(active?.textContent).toBe("By month");
 	});
 
 	it("falls back to 'hour' when stored tab is invalid", () => {

--- a/src/test/announcement-banner.test.tsx
+++ b/src/test/announcement-banner.test.tsx
@@ -83,9 +83,7 @@ describe("AnnouncementBanner", () => {
 				}),
 				container,
 			);
-			const dismissBtn = container.querySelector(
-				".announcement-banner-dismiss",
-			) as HTMLButtonElement;
+			const dismissBtn = container.querySelector(".announcement-banner-dismiss") as HTMLButtonElement;
 			expect(dismissBtn).not.toBeNull();
 			dismissBtn.click();
 			expect(onDismiss).toHaveBeenCalledTimes(1);

--- a/src/test/artist-enrichment.test.ts
+++ b/src/test/artist-enrichment.test.ts
@@ -70,10 +70,7 @@ describe("enrichArtists", () => {
 		cosmosGetMock.mockResolvedValueOnce({
 			ok: true,
 			data: {
-				artists: [
-					makeSpotifyArtist("id001", "Artist 1", []),
-					makeSpotifyArtist("id002", "Artist 2", []),
-				],
+				artists: [makeSpotifyArtist("id001", "Artist 1", []), makeSpotifyArtist("id002", "Artist 2", [])],
 			},
 		});
 
@@ -107,9 +104,7 @@ describe("enrichArtists", () => {
 		cosmosGetMock.mockResolvedValueOnce({
 			ok: true,
 			data: {
-				artists: [
-					makeSpotifyArtist("wr001", "Write Test Artist", ["indie"], "https://img.url/wr001.jpg"),
-				],
+				artists: [makeSpotifyArtist("wr001", "Write Test Artist", ["indie"], "https://img.url/wr001.jpg")],
 			},
 		});
 
@@ -127,9 +122,7 @@ describe("enrichArtists", () => {
 		cosmosGetMock.mockResolvedValueOnce({
 			ok: true,
 			data: {
-				artists: [
-					makeSpotifyArtist("rec001", "Record Artist", ["ambient"], "https://img.url/rec001.jpg"),
-				],
+				artists: [makeSpotifyArtist("rec001", "Record Artist", ["ambient"], "https://img.url/rec001.jpg")],
 			},
 		});
 

--- a/src/test/capabilities.test.ts
+++ b/src/test/capabilities.test.ts
@@ -16,7 +16,7 @@ const localCaps: ProviderCapabilities = {
 };
 
 const statsfmPlusCaps: ProviderCapabilities = {
-	hasActivityData: false,
+	hasActivityData: true,
 	hasConsistencyData: true,
 	hasGenreData: true,
 	hasStreakData: false,
@@ -25,7 +25,7 @@ const statsfmPlusCaps: ProviderCapabilities = {
 };
 
 const statsfmFreeCaps: ProviderCapabilities = {
-	hasActivityData: false,
+	hasActivityData: true,
 	hasConsistencyData: true,
 	hasGenreData: true,
 	hasStreakData: false,
@@ -47,20 +47,20 @@ describe("getSectionsForProvider", () => {
 		]);
 	});
 
-	it("excludes activity section for stats.fm Plus (no activity data from API)", () => {
+	it("includes activity section for stats.fm Plus (activity data available)", () => {
 		const sections = getSectionsForProvider(statsfmPlusCaps);
 		const ids = sections.map((s) => s.id);
-		expect(ids).not.toContain("activity");
+		expect(ids).toContain("activity");
 		expect(ids).toContain("consistency");
-		expect(ids).toEqual(["overview", "top-genres", "top-lists", "consistency", "recently-played"]);
+		expect(ids).toEqual(["overview", "top-genres", "top-lists", "activity", "consistency", "recently-played"]);
 	});
 
-	it("excludes activity section for stats.fm free tier (no activity data)", () => {
+	it("includes activity section for stats.fm free tier (activity data available)", () => {
 		const sections = getSectionsForProvider(statsfmFreeCaps);
 		const ids = sections.map((s) => s.id);
-		expect(ids).not.toContain("activity");
+		expect(ids).toContain("activity");
 		expect(ids).toContain("consistency");
-		expect(ids).toEqual(["overview", "top-genres", "top-lists", "consistency", "recently-played"]);
+		expect(ids).toEqual(["overview", "top-genres", "top-lists", "activity", "consistency", "recently-played"]);
 	});
 
 	it("excludes top-genres when hasGenreData is false", () => {
@@ -95,7 +95,7 @@ describe("getOverviewTilesForProvider", () => {
 		expect(ids).not.toContain("peak-hour");
 	});
 
-	it("stats.fm tile catalog excludes streak without API data", () => {
+	it("stats.fm tile catalog does not include streak tile", () => {
 		const tiles = getOverviewTilesForProvider("statsfm", statsfmPlusCaps);
 		const streak = tiles.find((t) => t.id === "streak");
 		expect(streak).toBeUndefined();
@@ -136,12 +136,12 @@ describe("getActivityMode", () => {
 		expect(getActivityMode(localCaps)).toBe("full");
 	});
 
-	it("returns 'hidden' for stats.fm Plus without activity data", () => {
-		expect(getActivityMode(statsfmPlusCaps)).toBe("hidden");
+	it("returns 'full' for stats.fm Plus with activity data", () => {
+		expect(getActivityMode(statsfmPlusCaps)).toBe("full");
 	});
 
-	it("returns 'hidden' for stats.fm free tier without activity data", () => {
-		expect(getActivityMode(statsfmFreeCaps)).toBe("hidden");
+	it("returns 'full' for stats.fm free tier with activity data", () => {
+		expect(getActivityMode(statsfmFreeCaps)).toBe("full");
 	});
 
 	it("returns 'hidden' when activity section is not applicable", () => {

--- a/src/test/capabilities.test.ts
+++ b/src/test/capabilities.test.ts
@@ -1,9 +1,5 @@
 import { describe, expect, it } from "vitest";
-import {
-	getActivityMode,
-	getOverviewTilesForProvider,
-	getSectionsForProvider,
-} from "../app/capabilities";
+import { getActivityMode, getOverviewTilesForProvider, getSectionsForProvider } from "../app/capabilities";
 import type { ProviderCapabilities } from "../shared/stats/provider";
 
 const localCaps: ProviderCapabilities = {
@@ -37,14 +33,7 @@ describe("getSectionsForProvider", () => {
 	it("returns all 6 sections for local provider", () => {
 		const sections = getSectionsForProvider(localCaps);
 		const ids = sections.map((s) => s.id);
-		expect(ids).toEqual([
-			"overview",
-			"top-genres",
-			"top-lists",
-			"activity",
-			"consistency",
-			"recently-played",
-		]);
+		expect(ids).toEqual(["overview", "top-genres", "top-lists", "activity", "consistency", "recently-played"]);
 	});
 
 	it("includes activity section for stats.fm Plus (activity data available)", () => {

--- a/src/test/dashboard-layout.test.ts
+++ b/src/test/dashboard-layout.test.ts
@@ -268,8 +268,7 @@ describe("buildStatsFmTooltip", () => {
 	});
 
 	it("truncates lastError > 60 chars with ellipsis", () => {
-		const longError =
-			"This is a very long error message that exceeds sixty characters in total length";
+		const longError = "This is a very long error message that exceeds sixty characters in total length";
 		const health: StatsFmHealthPayload = {
 			lastFetchAt: FROZEN_MS,
 			lastSuccessAt: null,
@@ -409,30 +408,21 @@ describe("EmptyState component", () => {
 	it('renders "No listening data yet" text', async () => {
 		const EmptyState = (await import("../app/components/EmptyState")).default;
 		const onOpenSettings = vi.fn();
-		Spicetify.ReactDOM.render(
-			Spicetify.React.createElement(EmptyState, { onOpenSettings }),
-			container,
-		);
+		Spicetify.ReactDOM.render(Spicetify.React.createElement(EmptyState, { onOpenSettings }), container);
 		expect(container.textContent).toContain("No listening data yet");
 	});
 
 	it('renders "Open Settings" button', async () => {
 		const EmptyState = (await import("../app/components/EmptyState")).default;
 		const onOpenSettings = vi.fn();
-		Spicetify.ReactDOM.render(
-			Spicetify.React.createElement(EmptyState, { onOpenSettings }),
-			container,
-		);
+		Spicetify.ReactDOM.render(Spicetify.React.createElement(EmptyState, { onOpenSettings }), container);
 		expect(container.textContent).toContain("Open Settings");
 	});
 
 	it("calls onOpenSettings when button is clicked", async () => {
 		const EmptyState = (await import("../app/components/EmptyState")).default;
 		const onOpenSettings = vi.fn();
-		Spicetify.ReactDOM.render(
-			Spicetify.React.createElement(EmptyState, { onOpenSettings }),
-			container,
-		);
+		Spicetify.ReactDOM.render(Spicetify.React.createElement(EmptyState, { onOpenSettings }), container);
 		const button = container.querySelector("button");
 		button?.click();
 		expect(onOpenSettings).toHaveBeenCalledOnce();
@@ -607,9 +597,7 @@ describe("OverviewCards tooltips", () => {
 			},
 		];
 		const filtered = filterOverviewCards(testCards, localCaps);
-		expect(filtered[0].tooltip).toBe(
-			"Consecutive calendar days with at least one play (local timezone)",
-		);
+		expect(filtered[0].tooltip).toBe("Consecutive calendar days with at least one play (local timezone)");
 	});
 
 	it("shows Listening Days tooltip for stats.fm provider", async () => {
@@ -622,9 +610,7 @@ describe("OverviewCards tooltips", () => {
 			},
 		];
 		const filtered = filterOverviewCards(testCards, statsfmFreeCaps);
-		expect(filtered[0].tooltip).toBe(
-			"Number of days with at least one play in the selected period",
-		);
+		expect(filtered[0].tooltip).toBe("Number of days with at least one play in the selected period");
 	});
 
 	it("renders stat grid cards for stats.fm provider plus hero cell", async () => {
@@ -660,20 +646,14 @@ describe("RecentlyPlayedSkeleton component", () => {
 
 	it("renders 6 items with recently-played-item wrapper", async () => {
 		const { RecentlyPlayedSkeleton } = await import("../app/components/LoadingSkeleton");
-		Spicetify.ReactDOM.render(
-			Spicetify.React.createElement(RecentlyPlayedSkeleton, null),
-			container,
-		);
+		Spicetify.ReactDOM.render(Spicetify.React.createElement(RecentlyPlayedSkeleton, null), container);
 		const items = container.querySelectorAll(".recently-played-item");
 		expect(items).toHaveLength(6);
 	});
 
 	it("each item has a 120x120 skeleton art div", async () => {
 		const { RecentlyPlayedSkeleton } = await import("../app/components/LoadingSkeleton");
-		Spicetify.ReactDOM.render(
-			Spicetify.React.createElement(RecentlyPlayedSkeleton, null),
-			container,
-		);
+		Spicetify.ReactDOM.render(Spicetify.React.createElement(RecentlyPlayedSkeleton, null), container);
 		const arts = container.querySelectorAll(".recently-played-skeleton-art");
 		expect(arts).toHaveLength(6);
 		arts.forEach((art) => {
@@ -683,10 +663,7 @@ describe("RecentlyPlayedSkeleton component", () => {
 
 	it("each item has text and subtext skeleton lines", async () => {
 		const { RecentlyPlayedSkeleton } = await import("../app/components/LoadingSkeleton");
-		Spicetify.ReactDOM.render(
-			Spicetify.React.createElement(RecentlyPlayedSkeleton, null),
-			container,
-		);
+		Spicetify.ReactDOM.render(Spicetify.React.createElement(RecentlyPlayedSkeleton, null), container);
 		const texts = container.querySelectorAll(".recently-played-skeleton-text");
 		const subtexts = container.querySelectorAll(".recently-played-skeleton-subtext");
 		expect(texts).toHaveLength(6);
@@ -695,10 +672,7 @@ describe("RecentlyPlayedSkeleton component", () => {
 
 	it("renders inside a recently-played container with aria-hidden", async () => {
 		const { RecentlyPlayedSkeleton } = await import("../app/components/LoadingSkeleton");
-		Spicetify.ReactDOM.render(
-			Spicetify.React.createElement(RecentlyPlayedSkeleton, null),
-			container,
-		);
+		Spicetify.ReactDOM.render(Spicetify.React.createElement(RecentlyPlayedSkeleton, null), container);
 		const wrapper = container.querySelector(".recently-played");
 		expect(wrapper).not.toBeNull();
 		expect(wrapper?.getAttribute("aria-hidden")).toBe("true");

--- a/src/test/display-tab-variant.test.tsx
+++ b/src/test/display-tab-variant.test.tsx
@@ -23,20 +23,14 @@ describe("DisplayTab playCountVariant toggle", () => {
 
 	it("renders play count variant selector with 4 options", async () => {
 		const { DisplayTab } = await import("../app/components/settings/DisplayTab");
-		Spicetify.ReactDOM.render(
-			Spicetify.React.createElement(DisplayTab, { onPrefsChanged: vi.fn() }),
-			container,
-		);
+		Spicetify.ReactDOM.render(Spicetify.React.createElement(DisplayTab, { onPrefsChanged: vi.fn() }), container);
 		const buttons = container.querySelectorAll("[data-testid='play-count-variant'] button");
 		expect(buttons.length).toBe(4);
 	});
 
 	it("highlights the default 'pill' variant", async () => {
 		const { DisplayTab } = await import("../app/components/settings/DisplayTab");
-		Spicetify.ReactDOM.render(
-			Spicetify.React.createElement(DisplayTab, { onPrefsChanged: vi.fn() }),
-			container,
-		);
+		Spicetify.ReactDOM.render(Spicetify.React.createElement(DisplayTab, { onPrefsChanged: vi.fn() }), container);
 		const buttons = container.querySelectorAll("[data-testid='play-count-variant'] button");
 		const pillBtn = Array.from(buttons).find((b) => b.textContent === "Pill");
 		expect(pillBtn?.className).toContain("btn-primary");
@@ -45,10 +39,7 @@ describe("DisplayTab playCountVariant toggle", () => {
 	it("clicking 'Bubble' updates preference to bubble", async () => {
 		const onPrefsChanged = vi.fn();
 		const { DisplayTab } = await import("../app/components/settings/DisplayTab");
-		Spicetify.ReactDOM.render(
-			Spicetify.React.createElement(DisplayTab, { onPrefsChanged }),
-			container,
-		);
+		Spicetify.ReactDOM.render(Spicetify.React.createElement(DisplayTab, { onPrefsChanged }), container);
 		const buttons = container.querySelectorAll("[data-testid='play-count-variant'] button");
 		const bubbleBtn = Array.from(buttons).find((b) => b.textContent === "Bubble") as HTMLElement;
 		bubbleBtn.click();
@@ -59,10 +50,7 @@ describe("DisplayTab playCountVariant toggle", () => {
 	it("clicking 'Minimal' updates preference to minimal", async () => {
 		const onPrefsChanged = vi.fn();
 		const { DisplayTab } = await import("../app/components/settings/DisplayTab");
-		Spicetify.ReactDOM.render(
-			Spicetify.React.createElement(DisplayTab, { onPrefsChanged }),
-			container,
-		);
+		Spicetify.ReactDOM.render(Spicetify.React.createElement(DisplayTab, { onPrefsChanged }), container);
 		const buttons = container.querySelectorAll("[data-testid='play-count-variant'] button");
 		const minimalBtn = Array.from(buttons).find((b) => b.textContent === "Minimal") as HTMLElement;
 		minimalBtn.click();
@@ -73,10 +61,7 @@ describe("DisplayTab playCountVariant toggle", () => {
 	it("clicking 'Off' updates preference to off", async () => {
 		const onPrefsChanged = vi.fn();
 		const { DisplayTab } = await import("../app/components/settings/DisplayTab");
-		Spicetify.ReactDOM.render(
-			Spicetify.React.createElement(DisplayTab, { onPrefsChanged }),
-			container,
-		);
+		Spicetify.ReactDOM.render(Spicetify.React.createElement(DisplayTab, { onPrefsChanged }), container);
 		const buttons = container.querySelectorAll("[data-testid='play-count-variant'] button");
 		const offBtn = Array.from(buttons).find((b) => b.textContent === "Off") as HTMLElement;
 		offBtn.click();
@@ -86,10 +71,7 @@ describe("DisplayTab playCountVariant toggle", () => {
 
 	it("shows Extra play context row when local provider is active", async () => {
 		const { DisplayTab } = await import("../app/components/settings/DisplayTab");
-		Spicetify.ReactDOM.render(
-			Spicetify.React.createElement(DisplayTab, { onPrefsChanged: vi.fn() }),
-			container,
-		);
+		Spicetify.ReactDOM.render(Spicetify.React.createElement(DisplayTab, { onPrefsChanged: vi.fn() }), container);
 		const row = container.querySelector("[data-testid='play-count-extra-context']");
 		expect(row).not.toBeNull();
 		expect(row?.textContent).toMatch(/New play/);
@@ -99,10 +81,7 @@ describe("DisplayTab playCountVariant toggle", () => {
 		const { setPreference } = await import("../app/preferences");
 		setPreference("playCountVariant", "minimal");
 		const { DisplayTab } = await import("../app/components/settings/DisplayTab");
-		Spicetify.ReactDOM.render(
-			Spicetify.React.createElement(DisplayTab, { onPrefsChanged: vi.fn() }),
-			container,
-		);
+		Spicetify.ReactDOM.render(Spicetify.React.createElement(DisplayTab, { onPrefsChanged: vi.fn() }), container);
 		const buttons = container.querySelectorAll("[data-testid='play-count-variant'] button");
 		const minimalBtn = Array.from(buttons).find((b) => b.textContent === "Minimal");
 		expect(minimalBtn?.className).toContain("btn-primary");

--- a/src/test/error-classification.test.ts
+++ b/src/test/error-classification.test.ts
@@ -56,11 +56,7 @@ describe("classifyStatsFmError", () => {
 
 	it("preserves resetAt when provided", () => {
 		const resetAt = Date.now() + 30_000;
-		const err = classifyStatsFmError(
-			0,
-			"Circuit open  -  stats.fm temporarily unavailable",
-			resetAt,
-		);
+		const err = classifyStatsFmError(0, "Circuit open  -  stats.fm temporarily unavailable", resetAt);
 		expect(err.resetAt).toBe(resetAt);
 	});
 
@@ -72,13 +68,7 @@ describe("classifyStatsFmError", () => {
 
 describe("AppError type", () => {
 	it("has correct shape for all variants", () => {
-		const variants: AppError["variant"][] = [
-			"UserNotFound",
-			"NetworkError",
-			"ServiceDown",
-			"RateLimited",
-			"Unknown",
-		];
+		const variants: AppError["variant"][] = ["UserNotFound", "NetworkError", "ServiceDown", "RateLimited", "Unknown"];
 		for (const variant of variants) {
 			const err: AppError = { variant, message: "test", retryable: true };
 			expect(err.variant).toBe(variant);

--- a/src/test/format.test.ts
+++ b/src/test/format.test.ts
@@ -1,10 +1,5 @@
 import { describe, expect, it } from "vitest";
-import {
-	formatDuration,
-	formatEstimatedPayout,
-	formatHour,
-	formatRelativeTime,
-} from "../app/format";
+import { formatDuration, formatEstimatedPayout, formatHour, formatRelativeTime } from "../app/format";
 
 describe("formatDuration", () => {
 	it("returns '<1 min' for durations under 1 minute", () => {

--- a/src/test/genre-chips.test.ts
+++ b/src/test/genre-chips.test.ts
@@ -15,10 +15,7 @@ describe("GenreChips component", () => {
 
 	it("renders nothing when genres is undefined", async () => {
 		const { GenreChips } = await import("../app/components/GenreChips");
-		Spicetify.ReactDOM.render(
-			Spicetify.React.createElement(GenreChips, { genres: undefined }),
-			container,
-		);
+		Spicetify.ReactDOM.render(Spicetify.React.createElement(GenreChips, { genres: undefined }), container);
 		expect(container.innerHTML).toBe("");
 	});
 
@@ -30,10 +27,7 @@ describe("GenreChips component", () => {
 
 	it("does NOT emit .genre-chips wrapper when genres is undefined", async () => {
 		const { GenreChips } = await import("../app/components/GenreChips");
-		Spicetify.ReactDOM.render(
-			Spicetify.React.createElement(GenreChips, { genres: undefined }),
-			container,
-		);
+		Spicetify.ReactDOM.render(Spicetify.React.createElement(GenreChips, { genres: undefined }), container);
 		expect(container.querySelector(".genre-chips")).toBeNull();
 	});
 
@@ -45,10 +39,7 @@ describe("GenreChips component", () => {
 
 	it("renders exactly 1 .genre-chip for single-genre array", async () => {
 		const { GenreChips } = await import("../app/components/GenreChips");
-		Spicetify.ReactDOM.render(
-			Spicetify.React.createElement(GenreChips, { genres: ["pop"] }),
-			container,
-		);
+		Spicetify.ReactDOM.render(Spicetify.React.createElement(GenreChips, { genres: ["pop"] }), container);
 		const chips = container.querySelectorAll(".genre-chip");
 		expect(chips.length).toBe(1);
 		expect(chips[0]?.textContent).toBe("pop");
@@ -106,10 +97,7 @@ describe("GenreChips component", () => {
 
 	it("renders .genre-chips wrapper as a sibling div when chips exist", async () => {
 		const { GenreChips } = await import("../app/components/GenreChips");
-		Spicetify.ReactDOM.render(
-			Spicetify.React.createElement(GenreChips, { genres: ["pop"] }),
-			container,
-		);
+		Spicetify.ReactDOM.render(Spicetify.React.createElement(GenreChips, { genres: ["pop"] }), container);
 		expect(container.querySelector(".genre-chips")).not.toBeNull();
 	});
 

--- a/src/test/genre-filter.test.ts
+++ b/src/test/genre-filter.test.ts
@@ -40,10 +40,7 @@ describe("Genre filter pill preferences", () => {
 	});
 
 	it("pre-Phase-36 stored prefs without activeGenre get null default", async () => {
-		localStorage.setItem(
-			"listening-stats:preferences",
-			JSON.stringify({ use24HourTime: true, itemsPerSection: 10 }),
-		);
+		localStorage.setItem("listening-stats:preferences", JSON.stringify({ use24HourTime: true, itemsPerSection: 10 }));
 		const { getPreferences } = await import("../app/preferences");
 		expect(getPreferences().activeGenre).toBe(null);
 	});
@@ -56,17 +53,13 @@ describe("Genre filter FilterPill component", () => {
 
 	it("renders nothing when activeGenre is null", async () => {
 		const { FilterPill } = await import("../app/components/FilterPill");
-		const { container } = render(
-			React.createElement(FilterPill, { activeGenre: null, onClear: () => {} }),
-		);
+		const { container } = render(React.createElement(FilterPill, { activeGenre: null, onClear: () => {} }));
 		expect(container.querySelector(".filter-pill")).toBeNull();
 	});
 
 	it("renders pill with genre name when activeGenre is set", async () => {
 		const { FilterPill } = await import("../app/components/FilterPill");
-		const { container } = render(
-			React.createElement(FilterPill, { activeGenre: "indie folk", onClear: () => {} }),
-		);
+		const { container } = render(React.createElement(FilterPill, { activeGenre: "indie folk", onClear: () => {} }));
 		const pill = container.querySelector(".filter-pill");
 		expect(pill).not.toBeNull();
 		expect(pill?.textContent).toContain("Filtering by");
@@ -75,18 +68,14 @@ describe("Genre filter FilterPill component", () => {
 
 	it("renders filter icon inside pill", async () => {
 		const { FilterPill } = await import("../app/components/FilterPill");
-		const { container } = render(
-			React.createElement(FilterPill, { activeGenre: "rock", onClear: () => {} }),
-		);
+		const { container } = render(React.createElement(FilterPill, { activeGenre: "rock", onClear: () => {} }));
 		const icon = container.querySelector(".filter-pill-icon");
 		expect(icon).not.toBeNull();
 	});
 
 	it("renders dismiss button with × inside pill", async () => {
 		const { FilterPill } = await import("../app/components/FilterPill");
-		const { container } = render(
-			React.createElement(FilterPill, { activeGenre: "rock", onClear: () => {} }),
-		);
+		const { container } = render(React.createElement(FilterPill, { activeGenre: "rock", onClear: () => {} }));
 		const btn = container.querySelector(".filter-pill-close");
 		expect(btn).not.toBeNull();
 		expect(btn?.textContent).toBe("×");
@@ -110,9 +99,7 @@ describe("Genre filter FilterPill component", () => {
 
 	it("replaces displayed genre when activeGenre prop changes", async () => {
 		const { FilterPill } = await import("../app/components/FilterPill");
-		const { container, rerender } = render(
-			React.createElement(FilterPill, { activeGenre: "rock", onClear: () => {} }),
-		);
+		const { container, rerender } = render(React.createElement(FilterPill, { activeGenre: "rock", onClear: () => {} }));
 		expect(container.querySelector(".filter-pill")?.textContent).toContain("rock");
 		rerender(React.createElement(FilterPill, { activeGenre: "jazz", onClear: () => {} }));
 		expect(container.querySelector(".filter-pill")?.textContent).toContain("jazz");

--- a/src/test/guided-tour.test.tsx
+++ b/src/test/guided-tour.test.tsx
@@ -93,9 +93,7 @@ describe("GuidedTour integration", () => {
 			const nextBtn = document.querySelector(".tour-btn-next") as HTMLButtonElement;
 			nextBtn.click();
 		}
-		expect(document.body.textContent).toContain(
-			`Step ${TOUR_STEPS.length} of ${TOUR_STEPS.length}`,
-		);
+		expect(document.body.textContent).toContain(`Step ${TOUR_STEPS.length} of ${TOUR_STEPS.length}`);
 		const finishBtn = document.querySelector(".tour-btn-next") as HTMLButtonElement;
 		expect(finishBtn.textContent).toBe("Finish");
 		finishBtn.click();

--- a/src/test/header.test.tsx
+++ b/src/test/header.test.tsx
@@ -89,8 +89,6 @@ describe("Header period tabs slot", () => {
 		expect(nonActiveTab).toBeDefined();
 		nonActiveTab?.click();
 		expect(onPeriodChange).toHaveBeenCalledTimes(1);
-		expect(onPeriodChange).toHaveBeenCalledWith(
-			expect.objectContaining({ id: expect.any(String) }),
-		);
+		expect(onPeriodChange).toHaveBeenCalledWith(expect.objectContaining({ id: expect.any(String) }));
 	});
 });

--- a/src/test/health.test.ts
+++ b/src/test/health.test.ts
@@ -100,8 +100,7 @@ describe("HealthIndicator", () => {
 			health.recordSuccess("Track");
 			const calls = dispatchSpy.mock.calls;
 			const healthEvent = calls.find(
-				(c: [Event]) =>
-					c[0] instanceof CustomEvent && c[0].type === "listening-stats:health-changed",
+				(c: [Event]) => c[0] instanceof CustomEvent && c[0].type === "listening-stats:health-changed",
 			);
 			expect(healthEvent).toBeDefined();
 			const event = healthEvent?.[0] as CustomEvent | undefined;
@@ -112,8 +111,7 @@ describe("HealthIndicator", () => {
 			health.recordFailure("error");
 			const calls = dispatchSpy.mock.calls;
 			const healthEvent = calls.find(
-				(c: [Event]) =>
-					c[0] instanceof CustomEvent && c[0].type === "listening-stats:health-changed",
+				(c: [Event]) => c[0] instanceof CustomEvent && c[0].type === "listening-stats:health-changed",
 			);
 			expect(healthEvent).toBeDefined();
 			const event = healthEvent?.[0] as CustomEvent | undefined;

--- a/src/test/import.test.ts
+++ b/src/test/import.test.ts
@@ -122,9 +122,7 @@ describe("parseV1Csv", () => {
 	});
 
 	it("assigns synthetic URIs with listening-stats: prefix", async () => {
-		const csv = buildV1Csv([
-			"Track 1,Artist,Album,180000,150000,2024-01-01T10:00:00.000Z,2024-01-01T10:02:30.000Z",
-		]);
+		const csv = buildV1Csv(["Track 1,Artist,Album,180000,150000,2024-01-01T10:00:00.000Z,2024-01-01T10:02:30.000Z"]);
 		const result = await parseV1Csv(csv);
 		const ev = result.events[0];
 		expect(ev.trackUri).toMatch(/^listening-stats:track:/);
@@ -205,9 +203,7 @@ describe("parseV1Csv", () => {
 	});
 
 	it("returns ParseResult shape with events, errors, errorDetails", async () => {
-		const csv = buildV1Csv([
-			"Track 1,Artist,Album,180000,150000,2024-01-01T10:00:00.000Z,2024-01-01T10:02:30.000Z",
-		]);
+		const csv = buildV1Csv(["Track 1,Artist,Album,180000,150000,2024-01-01T10:00:00.000Z,2024-01-01T10:02:30.000Z"]);
 		const result = await parseV1Csv(csv);
 		expect(result).toHaveProperty("events");
 		expect(result).toHaveProperty("errors");
@@ -353,9 +349,7 @@ describe("parseJsonEvents", () => {
 			topArtists: [],
 			totalTimeMs: 0,
 		};
-		await expect(parseJsonEvents(JSON.stringify(statsResult))).rejects.toThrow(
-			"raw play events array",
-		);
+		await expect(parseJsonEvents(JSON.stringify(statsResult))).rejects.toThrow("raw play events array");
 	});
 
 	it("throws for non-array JSON  -  error message contains 'not a valid JSON' or 'raw play events array'", async () => {
@@ -400,10 +394,7 @@ describe("importFileEvents", () => {
 	});
 
 	it("inserts events into the DB and returns correct imported count", async () => {
-		const events = [
-			makePlayEvent({ startedAt: 1000 }),
-			makePlayEvent({ startedAt: 2000, trackName: "Track 2" }),
-		];
+		const events = [makePlayEvent({ startedAt: 1000 }), makePlayEvent({ startedAt: 2000, trackName: "Track 2" })];
 		const result = await importFileEvents(events);
 		expect(result.imported).toBe(2);
 		expect(result.skipped).toBe(0);
@@ -424,10 +415,7 @@ describe("importFileEvents", () => {
 	});
 
 	it("re-importing the same events skips all duplicates", async () => {
-		const events = [
-			makePlayEvent({ startedAt: 1000 }),
-			makePlayEvent({ startedAt: 2000, trackName: "Track 2" }),
-		];
+		const events = [makePlayEvent({ startedAt: 1000 }), makePlayEvent({ startedAt: 2000, trackName: "Track 2" })];
 		const first = await importFileEvents(events);
 		expect(first.imported).toBe(2);
 
@@ -518,9 +506,7 @@ describe("Integration: CSV parse then import", () => {
 	});
 
 	it("re-importing same CSV file deduplicates all events", async () => {
-		const csv = buildV1Csv([
-			"Track 1,Artist,Album,180000,150000,2024-01-01T10:00:00.000Z,2024-01-01T10:02:30.000Z",
-		]);
+		const csv = buildV1Csv(["Track 1,Artist,Album,180000,150000,2024-01-01T10:00:00.000Z,2024-01-01T10:02:30.000Z"]);
 		const parsed = await parseV1Csv(csv);
 		await importFileEvents(parsed.events);
 		const second = await importFileEvents(parsed.events);

--- a/src/test/issue41-regression.test.ts
+++ b/src/test/issue41-regression.test.ts
@@ -33,16 +33,9 @@ function setActiveProvider(id: "local" | "statsfm"): void {
 	providerRegistry.setActive(id);
 }
 
-async function renderOverview(
-	container: HTMLElement,
-	stats: StatsResult,
-	period: Period = mockPeriod,
-) {
+async function renderOverview(container: HTMLElement, stats: StatsResult, period: Period = mockPeriod) {
 	const OverviewSection = (await import("../app/components/OverviewSection")).default;
-	Spicetify.ReactDOM.render(
-		Spicetify.React.createElement(OverviewSection, { stats, activePeriod: period }),
-		container,
-	);
+	Spicetify.ReactDOM.render(Spicetify.React.createElement(OverviewSection, { stats, activePeriod: period }), container);
 }
 
 // ──────────────────────────────────────────────────────────────────────
@@ -133,9 +126,7 @@ describe("Issue 41: card reflow for missing/unavailable cards", () => {
 	it("hiddenSections: 'streak' excluded from rendered cards", async () => {
 		setPreference("hiddenSections", ["streak"]);
 		await renderOverview(container, { ...baseStats, streak: 3, newArtistCount: 5 });
-		const ids = Array.from(container.querySelectorAll("[data-card-id]")).map((c) =>
-			c.getAttribute("data-card-id"),
-		);
+		const ids = Array.from(container.querySelectorAll("[data-card-id]")).map((c) => c.getAttribute("data-card-id"));
 		expect(ids).not.toContain("streak");
 	});
 
@@ -184,19 +175,13 @@ describe("Issue 41: onboarding is in-page window", () => {
 
 	it("wizard does not use role=dialog", async () => {
 		const { SetupWizard } = await import("../app/components/SetupWizard");
-		Spicetify.ReactDOM.render(
-			Spicetify.React.createElement(SetupWizard, { onComplete: vi.fn() }),
-			container,
-		);
+		Spicetify.ReactDOM.render(Spicetify.React.createElement(SetupWizard, { onComplete: vi.fn() }), container);
 		expect(container.querySelector('[role="dialog"]')).toBeNull();
 	});
 
 	it("wizard does not use aria-modal", async () => {
 		const { SetupWizard } = await import("../app/components/SetupWizard");
-		Spicetify.ReactDOM.render(
-			Spicetify.React.createElement(SetupWizard, { onComplete: vi.fn() }),
-			container,
-		);
+		Spicetify.ReactDOM.render(Spicetify.React.createElement(SetupWizard, { onComplete: vi.fn() }), container);
 		expect(container.querySelector("[aria-modal]")).toBeNull();
 	});
 });

--- a/src/test/issue41-regression.test.ts
+++ b/src/test/issue41-regression.test.ts
@@ -121,14 +121,22 @@ describe("Issue 41: card reflow for missing/unavailable cards", () => {
 		localStorage.clear();
 	});
 
-	it("when newArtistCount missing, bottom row still shows three tiles (new artists defaults to 0)", async () => {
+	it("when newArtistCount missing, bottom row still shows tiles (new artists defaults to 0)", async () => {
 		await renderOverview(container, { ...baseStats, streak: 3 });
-		const bottomRow = container.querySelector<HTMLElement>(".overview-bottom-row");
-		expect(bottomRow).not.toBeNull();
-		const cards = bottomRow!.querySelectorAll(".overview-card");
-		expect(cards.length).toBe(3);
-		const cols = bottomRow?.style.gridTemplateColumns;
-		expect(cols).toContain("3");
+		const allCards = container.querySelectorAll(".overview-card");
+		expect(allCards.length).toBe(6);
+		const newArtists = container.querySelector('[data-card-id="new-artists"]');
+		expect(newArtists).not.toBeNull();
+		expect(newArtists?.querySelector(".overview-card-value")?.textContent).toBe("0");
+	});
+
+	it("hiddenSections: 'streak' excluded from rendered cards", async () => {
+		setPreference("hiddenSections", ["streak"]);
+		await renderOverview(container, { ...baseStats, streak: 3, newArtistCount: 5 });
+		const ids = Array.from(container.querySelectorAll("[data-card-id]")).map((c) =>
+			c.getAttribute("data-card-id"),
+		);
+		expect(ids).not.toContain("streak");
 	});
 
 	it("hiding a card via prefs does not leave an empty slot", async () => {
@@ -273,11 +281,9 @@ describe("Issue 41: no em-dash in UI values", () => {
 		localStorage.clear();
 	});
 
-	it("streak == 0 renders hyphen-minus, not em-dash", async () => {
+	it("streak tile is not rendered in overview", async () => {
 		await renderOverview(container, { ...baseStats, streak: 0, newArtistCount: 3 });
-		const streakCard = container.querySelector('[data-card-id="streak"]');
-		const value = streakCard?.querySelector(".overview-card-value");
-		expect(value?.textContent).toBe("-");
+		expect(container.querySelector('[data-card-id="streak"]')).toBeNull();
 	});
 
 	it("top-genre with empty topGenres renders hyphen-minus, not em-dash", async () => {

--- a/src/test/lastfm-settings.test.ts
+++ b/src/test/lastfm-settings.test.ts
@@ -48,9 +48,7 @@ describe("Last.fm section in ProvidersTab  -  idle state", () => {
 		const { ProvidersTab } = await import("../app/components/settings/ProvidersTab");
 		const { container } = render(React.createElement(ProvidersTab));
 		const btns = container.querySelectorAll("button.btn-primary");
-		const testBtn = Array.from(btns).find((b) =>
-			b.textContent?.includes("Test Connection"),
-		) as HTMLButtonElement;
+		const testBtn = Array.from(btns).find((b) => b.textContent?.includes("Test Connection")) as HTMLButtonElement;
 		expect(testBtn.disabled).toBe(true);
 	});
 });
@@ -60,14 +58,10 @@ describe("Last.fm section in ProvidersTab  -  validation flow", () => {
 		validateMock.mockResolvedValue({ valid: true });
 		const { ProvidersTab } = await import("../app/components/settings/ProvidersTab");
 		const { container } = render(React.createElement(ProvidersTab));
-		const input = container.querySelector(
-			"input[aria-label='Last.fm API key']",
-		) as HTMLInputElement;
+		const input = container.querySelector("input[aria-label='Last.fm API key']") as HTMLInputElement;
 		fireEvent.change(input, { target: { value: "good-key-123" } });
 		const btns = container.querySelectorAll("button.btn-primary");
-		const testBtn = Array.from(btns).find((b) =>
-			b.textContent?.includes("Test Connection"),
-		) as HTMLButtonElement;
+		const testBtn = Array.from(btns).find((b) => b.textContent?.includes("Test Connection")) as HTMLButtonElement;
 		fireEvent.click(testBtn);
 		await vi.waitFor(() => {
 			const status = container.querySelector("[role='status']");
@@ -79,14 +73,10 @@ describe("Last.fm section in ProvidersTab  -  validation flow", () => {
 		validateMock.mockResolvedValue({ valid: true });
 		const { ProvidersTab } = await import("../app/components/settings/ProvidersTab");
 		const { container } = render(React.createElement(ProvidersTab));
-		const input = container.querySelector(
-			"input[aria-label='Last.fm API key']",
-		) as HTMLInputElement;
+		const input = container.querySelector("input[aria-label='Last.fm API key']") as HTMLInputElement;
 		fireEvent.change(input, { target: { value: "good-key-123" } });
 		const btns = container.querySelectorAll("button.btn-primary");
-		const testBtn = Array.from(btns).find((b) =>
-			b.textContent?.includes("Test Connection"),
-		) as HTMLButtonElement;
+		const testBtn = Array.from(btns).find((b) => b.textContent?.includes("Test Connection")) as HTMLButtonElement;
 		fireEvent.click(testBtn);
 		await vi.waitFor(() => {
 			expect(localStorage.getItem("listening-stats:lastfm-api-key")).toBe("good-key-123");
@@ -97,14 +87,10 @@ describe("Last.fm section in ProvidersTab  -  validation flow", () => {
 		validateMock.mockResolvedValue({ valid: false, reason: "invalid_key" });
 		const { ProvidersTab } = await import("../app/components/settings/ProvidersTab");
 		const { container } = render(React.createElement(ProvidersTab));
-		const input = container.querySelector(
-			"input[aria-label='Last.fm API key']",
-		) as HTMLInputElement;
+		const input = container.querySelector("input[aria-label='Last.fm API key']") as HTMLInputElement;
 		fireEvent.change(input, { target: { value: "bad-key" } });
 		const btns = container.querySelectorAll("button.btn-primary");
-		const testBtn = Array.from(btns).find((b) =>
-			b.textContent?.includes("Test Connection"),
-		) as HTMLButtonElement;
+		const testBtn = Array.from(btns).find((b) => b.textContent?.includes("Test Connection")) as HTMLButtonElement;
 		fireEvent.click(testBtn);
 		await vi.waitFor(() => {
 			const error = container.querySelector("[role='alert']");
@@ -137,9 +123,7 @@ describe("Last.fm section in ProvidersTab  -  connected state", () => {
 		const { ProvidersTab } = await import("../app/components/settings/ProvidersTab");
 		const { container } = render(React.createElement(ProvidersTab));
 		const btns = container.querySelectorAll("button.btn-destructive");
-		const disconnectBtn = Array.from(btns).find((b) =>
-			b.textContent?.includes("Disconnect"),
-		) as HTMLButtonElement;
+		const disconnectBtn = Array.from(btns).find((b) => b.textContent?.includes("Disconnect")) as HTMLButtonElement;
 		fireEvent.click(disconnectBtn);
 		await vi.waitFor(() => {
 			expect(localStorage.getItem("listening-stats:lastfm-api-key")).toBeNull();

--- a/src/test/local-provider.test.ts
+++ b/src/test/local-provider.test.ts
@@ -75,13 +75,7 @@ describe("LocalProvider", () => {
 		it("returns LOCAL_PERIODS (5 periods)", () => {
 			const periods = provider.getSupportedPeriods();
 			expect(periods).toHaveLength(5);
-			expect(periods.map((p) => p.id)).toEqual([
-				"today",
-				"this-week",
-				"this-month",
-				"last-6-months",
-				"all-time",
-			]);
+			expect(periods.map((p) => p.id)).toEqual(["today", "this-week", "this-month", "last-6-months", "all-time"]);
 		});
 	});
 
@@ -301,9 +295,7 @@ describe("LocalProvider", () => {
 
 		it("calculateStats calls enrichArtists with artist URIs from results", async () => {
 			const artistUri = "spotify:artist:enrich_me";
-			await db.playEvents.add(
-				makePlayEvent({ artistUri, artistName: "Enrich Me", startedAt: 1000 }),
-			);
+			await db.playEvents.add(makePlayEvent({ artistUri, artistName: "Enrich Me", startedAt: 1000 }));
 
 			await provider.calculateStats(allTimePeriod);
 
@@ -314,9 +306,7 @@ describe("LocalProvider", () => {
 
 		it("topGenres populated from db.artists enrichment data", async () => {
 			const artistUri = "spotify:artist:genretest";
-			await db.playEvents.add(
-				makePlayEvent({ artistUri, artistName: "Genre Test", startedAt: 1000 }),
-			);
+			await db.playEvents.add(makePlayEvent({ artistUri, artistName: "Genre Test", startedAt: 1000 }));
 
 			// Pre-populate db.artists with genre data (simulating already-enriched)
 			await db.artists.put({
@@ -457,9 +447,7 @@ describe("LocalProvider", () => {
 		});
 
 		it("returns streak=1 when only today has a play event", async () => {
-			await db.playEvents.add(
-				makePlayEvent({ startedAt: new Date(2026, 3, 1, 12, 0, 0).getTime() }),
-			);
+			await db.playEvents.add(makePlayEvent({ startedAt: new Date(2026, 3, 1, 12, 0, 0).getTime() }));
 
 			const result = await provider.calculateStats(allTimePeriod);
 			expect(result.streak).toBe(1);
@@ -467,9 +455,7 @@ describe("LocalProvider", () => {
 
 		it("returns streak=0 when last play was 2+ days ago (grace period expired)", async () => {
 			// Event only 3 days ago  -  no event yesterday or today
-			await db.playEvents.add(
-				makePlayEvent({ startedAt: new Date(2026, 2, 29, 12, 0, 0).getTime() }),
-			);
+			await db.playEvents.add(makePlayEvent({ startedAt: new Date(2026, 2, 29, 12, 0, 0).getTime() }));
 
 			const result = await provider.calculateStats(allTimePeriod);
 			expect(result.streak).toBe(0);
@@ -478,9 +464,7 @@ describe("LocalProvider", () => {
 		it("streak uses local timezone day boundaries, not UTC", async () => {
 			// Event at 11:30 PM local time  -  this must count as "today" in local TZ
 			// Using new Date(2026, 3, 1, 23, 30, 0) which is local timezone aware
-			await db.playEvents.add(
-				makePlayEvent({ startedAt: new Date(2026, 3, 1, 23, 30, 0).getTime() }),
-			);
+			await db.playEvents.add(makePlayEvent({ startedAt: new Date(2026, 3, 1, 23, 30, 0).getTime() }));
 
 			const result = await provider.calculateStats(allTimePeriod);
 			// The 11:30 PM event should count as today, giving streak of 1

--- a/src/test/migration.test.ts
+++ b/src/test/migration.test.ts
@@ -1,11 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import * as backup from "../shared/storage/backup";
 import { db, registerVersionChangeHandler } from "../shared/storage/db";
-import {
-	backupIfUpgradeNeeded,
-	initDatabase,
-	MIGRATIONS,
-} from "../shared/storage/migration-manager";
+import { backupIfUpgradeNeeded, initDatabase, MIGRATIONS } from "../shared/storage/migration-manager";
 import type { PlayEvent } from "../shared/types/play-event";
 import type { ArtistRecord } from "../shared/types/stats";
 

--- a/src/test/overview-section.test.ts
+++ b/src/test/overview-section.test.ts
@@ -47,10 +47,7 @@ function renderOverview(stats: StatsResult, activePeriod: Period = mockPeriods[0
 	// shared `container` (set up in each describe's beforeEach).
 	return async (container: HTMLElement) => {
 		const OverviewSection = (await import("../app/components/OverviewSection")).default;
-		Spicetify.ReactDOM.render(
-			Spicetify.React.createElement(OverviewSection, { stats, activePeriod }),
-			container,
-		);
+		Spicetify.ReactDOM.render(Spicetify.React.createElement(OverviewSection, { stats, activePeriod }), container);
 	};
 }
 
@@ -283,14 +280,7 @@ describe("OverviewSection grid topology", () => {
 		await renderOverview({ ...baseStats, streak: 3, newArtistCount: 5 })(container);
 		const cards = container.querySelectorAll("[data-card-id]");
 		const ids = Array.from(cards).map((c) => c.getAttribute("data-card-id"));
-		expect(ids).toEqual([
-			"tracks",
-			"unique-artists",
-			"new-artists",
-			"peak-hour",
-			"skip-rate",
-			"est-payout",
-		]);
+		expect(ids).toEqual(["tracks", "unique-artists", "new-artists", "peak-hour", "skip-rate", "est-payout"]);
 	});
 });
 
@@ -313,17 +303,8 @@ describe("OverviewSection tiles by provider", () => {
 	it("Local provider with 6 IDs and newArtistCount defined renders all 6 tiles in default order", async () => {
 		setActiveProvider("local");
 		await renderOverview({ ...baseStats, streak: 3, newArtistCount: 5 })(container);
-		const ids = Array.from(container.querySelectorAll("[data-card-id]")).map((c) =>
-			c.getAttribute("data-card-id"),
-		);
-		expect(ids).toEqual([
-			"tracks",
-			"unique-artists",
-			"new-artists",
-			"peak-hour",
-			"skip-rate",
-			"est-payout",
-		]);
+		const ids = Array.from(container.querySelectorAll("[data-card-id]")).map((c) => c.getAttribute("data-card-id"));
+		expect(ids).toEqual(["tracks", "unique-artists", "new-artists", "peak-hour", "skip-rate", "est-payout"]);
 	});
 
 	it("stats.fm provider renders top-genre in place of peak-hour, hides tracks and skip-rate", async () => {
@@ -334,9 +315,7 @@ describe("OverviewSection tiles by provider", () => {
 			newArtistCount: 5,
 			topGenres: [{ rank: 1, genre: "indie rock", count: 42 } as any],
 		})(container);
-		const ids = Array.from(container.querySelectorAll("[data-card-id]")).map((c) =>
-			c.getAttribute("data-card-id"),
-		);
+		const ids = Array.from(container.querySelectorAll("[data-card-id]")).map((c) => c.getAttribute("data-card-id"));
 		expect(ids).toEqual(["unique-artists", "new-artists", "top-genre", "est-payout"]);
 		expect(ids).not.toContain("tracks");
 		expect(ids).not.toContain("peak-hour");
@@ -403,20 +382,11 @@ describe("OverviewSection ordering and hide prefs", () => {
 
 	it("respects custom overviewOrder.local  -  cards rendered in user's stored order", async () => {
 		setPreference("overviewOrder", {
-			local: [
-				"est-payout",
-				"tracks",
-				"unique-artists",
-				"new-artists",
-				"peak-hour",
-				"skip-rate",
-			],
+			local: ["est-payout", "tracks", "unique-artists", "new-artists", "peak-hour", "skip-rate"],
 			statsfm: ["top-genre", "unique-artists", "new-artists", "est-payout"],
 		});
 		await renderOverview({ ...baseStats, streak: 3, newArtistCount: 5 })(container);
-		const ids = Array.from(container.querySelectorAll("[data-card-id]")).map((c) =>
-			c.getAttribute("data-card-id"),
-		);
+		const ids = Array.from(container.querySelectorAll("[data-card-id]")).map((c) => c.getAttribute("data-card-id"));
 		expect(ids[0]).toBe("est-payout");
 		expect(ids[1]).toBe("tracks");
 	});

--- a/src/test/overview-section.test.ts
+++ b/src/test/overview-section.test.ts
@@ -252,7 +252,7 @@ describe("OverviewSection grid topology", () => {
 	});
 
 	it("renders .overview-right-block containing top 4 visible tiles", async () => {
-		// newArtistCount provided → all 7 IDs visible → top4 = first 4 = tracks/unique-artists/streak/new-artists
+		// newArtistCount provided → 6 IDs visible → top4 = first 4 = tracks/unique-artists/new-artists/peak-hour
 		await renderOverview({ ...baseStats, streak: 3, newArtistCount: 5 })(container);
 		const rightBlock = container.querySelector(".overview-right-block");
 		expect(rightBlock).not.toBeNull();
@@ -260,23 +260,23 @@ describe("OverviewSection grid topology", () => {
 		expect(cards.length).toBe(4);
 	});
 
-	it("renders .overview-bottom-row containing next 3 visible tiles", async () => {
+	it("renders .overview-bottom-row containing next 2 visible tiles", async () => {
 		await renderOverview({ ...baseStats, streak: 3, newArtistCount: 5 })(container);
 		const bottomRow = container.querySelector(".overview-bottom-row");
 		expect(bottomRow).not.toBeNull();
 		const cards = bottomRow!.querySelectorAll(".overview-card");
-		expect(cards.length).toBe(3);
+		expect(cards.length).toBe(2);
 	});
 
-	it("when newArtistCount is undefined, all 7 tiles render (new artists shows 0)", async () => {
+	it("when newArtistCount is undefined, all 6 tiles render (streak no longer in overview)", async () => {
 		await renderOverview({ ...baseStats, streak: 3 })(container);
 		const allCards = container.querySelectorAll(".overview-card");
-		expect(allCards.length).toBe(7);
+		expect(allCards.length).toBe(6);
 		const newArtists = container.querySelector('[data-card-id="new-artists"]');
 		expect(newArtists).not.toBeNull();
 		expect(newArtists?.querySelector(".overview-card-value")?.textContent).toBe("0");
 		expect(container.querySelectorAll(".overview-right-block .overview-card").length).toBe(4);
-		expect(container.querySelectorAll(".overview-bottom-row .overview-card").length).toBe(3);
+		expect(container.querySelectorAll(".overview-bottom-row .overview-card").length).toBe(2);
 	});
 
 	it("data-card-id attributes preserved on all tiles", async () => {
@@ -286,7 +286,6 @@ describe("OverviewSection grid topology", () => {
 		expect(ids).toEqual([
 			"tracks",
 			"unique-artists",
-			"streak",
 			"new-artists",
 			"peak-hour",
 			"skip-rate",
@@ -311,7 +310,7 @@ describe("OverviewSection tiles by provider", () => {
 		localStorage.clear();
 	});
 
-	it("Local provider with 7 IDs and newArtistCount defined renders all 7 tiles in default order", async () => {
+	it("Local provider with 6 IDs and newArtistCount defined renders all 6 tiles in default order", async () => {
 		setActiveProvider("local");
 		await renderOverview({ ...baseStats, streak: 3, newArtistCount: 5 })(container);
 		const ids = Array.from(container.querySelectorAll("[data-card-id]")).map((c) =>
@@ -320,7 +319,6 @@ describe("OverviewSection tiles by provider", () => {
 		expect(ids).toEqual([
 			"tracks",
 			"unique-artists",
-			"streak",
 			"new-artists",
 			"peak-hour",
 			"skip-rate",
@@ -328,7 +326,7 @@ describe("OverviewSection tiles by provider", () => {
 		]);
 	});
 
-	it("stats.fm provider renders top-genre in place of peak-hour, hides streak and skip-rate, tracks in hero only", async () => {
+	it("stats.fm provider renders top-genre in place of peak-hour, hides tracks and skip-rate", async () => {
 		setActiveProvider("statsfm");
 		await renderOverview({
 			...baseStats,
@@ -346,8 +344,8 @@ describe("OverviewSection tiles by provider", () => {
 		expect(ids).not.toContain("skip-rate");
 	});
 
-	it("stats.fm streak tile is hidden (data not available from stats.fm API)", async () => {
-		setActiveProvider("statsfm");
+	it("streak tile is hidden from overview", async () => {
+		setActiveProvider("local");
 		await renderOverview({ ...baseStats, streak: 7, newArtistCount: 5 })(container);
 		expect(container.querySelector('[data-card-id="streak"]')).toBeNull();
 	});
@@ -356,25 +354,6 @@ describe("OverviewSection tiles by provider", () => {
 		setActiveProvider("statsfm");
 		await renderOverview({ ...baseStats, streak: 0, skipRate: 0.5, newArtistCount: 5 })(container);
 		expect(container.querySelector('[data-card-id="skip-rate"]')).toBeNull();
-	});
-
-	it("Local: streak tile with stats.streak > 0 has accent color on value span", async () => {
-		setActiveProvider("local");
-		await renderOverview({ ...baseStats, streak: 5, newArtistCount: 3 })(container);
-		const streakCard = container.querySelector('[data-card-id="streak"]');
-		const value = streakCard?.querySelector<HTMLElement>(".overview-card-value");
-		expect(value).not.toBeNull();
-		expect(value?.style.color).toContain("--spice-button");
-	});
-
-	it("Local: streak tile with stats.streak == 0 renders dash without accent", async () => {
-		setActiveProvider("local");
-		await renderOverview({ ...baseStats, streak: 0, newArtistCount: 3 })(container);
-		const streakCard = container.querySelector('[data-card-id="streak"]');
-		const value = streakCard?.querySelector<HTMLElement>(".overview-card-value");
-		expect(value?.textContent).toBe("-");
-		// No accent inline style applied
-		expect(value?.style.color === "" || !value?.style.color.includes("--spice-button")).toBe(true);
 	});
 
 	it("new-artists tile shows 0 when stats.newArtistCount is undefined", async () => {
@@ -425,13 +404,12 @@ describe("OverviewSection ordering and hide prefs", () => {
 	it("respects custom overviewOrder.local  -  cards rendered in user's stored order", async () => {
 		setPreference("overviewOrder", {
 			local: [
-				"streak",
+				"est-payout",
 				"tracks",
 				"unique-artists",
 				"new-artists",
 				"peak-hour",
 				"skip-rate",
-				"est-payout",
 			],
 			statsfm: ["top-genre", "unique-artists", "new-artists", "est-payout"],
 		});
@@ -439,7 +417,7 @@ describe("OverviewSection ordering and hide prefs", () => {
 		const ids = Array.from(container.querySelectorAll("[data-card-id]")).map((c) =>
 			c.getAttribute("data-card-id"),
 		);
-		expect(ids[0]).toBe("streak");
+		expect(ids[0]).toBe("est-payout");
 		expect(ids[1]).toBe("tracks");
 	});
 

--- a/src/test/period-persistence.test.ts
+++ b/src/test/period-persistence.test.ts
@@ -1,9 +1,5 @@
 import { beforeEach, describe, expect, it } from "vitest";
-import {
-	restorePeriodForProvider,
-	safeParseProviderPeriods,
-	savePeriodForProvider,
-} from "../app/App";
+import { restorePeriodForProvider, safeParseProviderPeriods, savePeriodForProvider } from "../app/App";
 import { LS_KEYS } from "../shared/constants/storage-keys";
 import type { Period } from "../shared/types/stats";
 
@@ -29,10 +25,7 @@ describe("safeParseProviderPeriods", () => {
 	});
 
 	it("returns parsed map when localStorage has valid JSON", () => {
-		localStorage.setItem(
-			LS_KEYS.PROVIDER_PERIODS,
-			JSON.stringify({ local: "this-week", statsfm: "sfm-months" }),
-		);
+		localStorage.setItem(LS_KEYS.PROVIDER_PERIODS, JSON.stringify({ local: "this-week", statsfm: "sfm-months" }));
 		expect(safeParseProviderPeriods()).toEqual({ local: "this-week", statsfm: "sfm-months" });
 	});
 
@@ -78,10 +71,7 @@ describe("restorePeriodForProvider", () => {
 	});
 
 	it("restores correct period for each provider independently (switching providers test)", () => {
-		localStorage.setItem(
-			LS_KEYS.PROVIDER_PERIODS,
-			JSON.stringify({ local: "this-month", statsfm: "sfm-weeks" }),
-		);
+		localStorage.setItem(LS_KEYS.PROVIDER_PERIODS, JSON.stringify({ local: "this-month", statsfm: "sfm-weeks" }));
 		const localResult = restorePeriodForProvider("local", mockPeriods);
 		const sfmResult = restorePeriodForProvider("statsfm", mockSfmPeriods);
 		expect(localResult.id).toBe("this-month");

--- a/src/test/periods.test.ts
+++ b/src/test/periods.test.ts
@@ -1,9 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import {
-	getAdjacentPeriod,
-	getPriorPeriodBoundaries,
-	LOCAL_PERIODS,
-} from "../shared/stats/periods";
+import { getAdjacentPeriod, getPriorPeriodBoundaries, LOCAL_PERIODS } from "../shared/stats/periods";
 import type { Period } from "../shared/types/stats";
 
 describe("Period boundary functions", () => {

--- a/src/test/playbar-widget.test.tsx
+++ b/src/test/playbar-widget.test.tsx
@@ -5,11 +5,7 @@ import { providerRegistry } from "../shared/stats/provider";
 import { db } from "../shared/storage/db";
 import type { PlayEvent } from "../shared/types/play-event";
 
-function makePlayEvent(
-	trackUri: string,
-	startedAt: number,
-	overrides?: Partial<PlayEvent>,
-): PlayEvent {
+function makePlayEvent(trackUri: string, startedAt: number, overrides?: Partial<PlayEvent>): PlayEvent {
 	return {
 		trackUri,
 		trackName: "Test Track",
@@ -118,10 +114,7 @@ describe("PlaybarWidget", () => {
 	it("renders bubble variant when preference is set to bubble", async () => {
 		setPreference("playCountVariant", "bubble");
 		const uri = "spotify:track:abc123";
-		await db.playEvents.bulkAdd([
-			makePlayEvent(uri, Date.now() - 60000),
-			makePlayEvent(uri, Date.now()),
-		]);
+		await db.playEvents.bulkAdd([makePlayEvent(uri, Date.now() - 60000), makePlayEvent(uri, Date.now())]);
 		(Spicetify.Player as any).data = {
 			isPaused: false,
 			item: { uri, name: "Test Track", metadata: {} },
@@ -135,10 +128,7 @@ describe("PlaybarWidget", () => {
 	it("renders minimal variant when preference is set to minimal", async () => {
 		setPreference("playCountVariant", "minimal");
 		const uri = "spotify:track:abc123";
-		await db.playEvents.bulkAdd([
-			makePlayEvent(uri, Date.now() - 60000),
-			makePlayEvent(uri, Date.now()),
-		]);
+		await db.playEvents.bulkAdd([makePlayEvent(uri, Date.now() - 60000), makePlayEvent(uri, Date.now())]);
 		(Spicetify.Player as any).data = {
 			isPaused: false,
 			item: { uri, name: "Test Track", metadata: {} },
@@ -151,10 +141,7 @@ describe("PlaybarWidget", () => {
 
 	it("renders pill even when active provider is stats.fm free tier", async () => {
 		const uri = "spotify:track:abc123";
-		await db.playEvents.bulkAdd([
-			makePlayEvent(uri, Date.now() - 60000),
-			makePlayEvent(uri, Date.now()),
-		]);
+		await db.playEvents.bulkAdd([makePlayEvent(uri, Date.now() - 60000), makePlayEvent(uri, Date.now())]);
 		(Spicetify.Player as any).data = {
 			isPaused: false,
 			item: { uri, name: "Test Track", metadata: {} },
@@ -188,10 +175,7 @@ describe("PlaybarWidget", () => {
 
 	it("renders when active provider is stats.fm Plus tier", async () => {
 		const uri = "spotify:track:abc123";
-		await db.playEvents.bulkAdd([
-			makePlayEvent(uri, Date.now() - 60000),
-			makePlayEvent(uri, Date.now()),
-		]);
+		await db.playEvents.bulkAdd([makePlayEvent(uri, Date.now() - 60000), makePlayEvent(uri, Date.now())]);
 		(Spicetify.Player as any).data = {
 			isPaused: false,
 			item: { uri, name: "Test Track", metadata: {} },
@@ -241,10 +225,7 @@ describe("PlaybarWidget", () => {
 
 	it("updates when PREFS_CHANGED event fires (variant switch)", async () => {
 		const uri = "spotify:track:abc123";
-		await db.playEvents.bulkAdd([
-			makePlayEvent(uri, Date.now() - 60000),
-			makePlayEvent(uri, Date.now()),
-		]);
+		await db.playEvents.bulkAdd([makePlayEvent(uri, Date.now() - 60000), makePlayEvent(uri, Date.now())]);
 		(Spicetify.Player as any).data = {
 			isPaused: false,
 			item: { uri, name: "Test Track", metadata: {} },
@@ -268,10 +249,7 @@ describe("PlaybarWidget", () => {
 		document.body.appendChild(nowPlayingWidget);
 
 		const uri = "spotify:track:abc123";
-		await db.playEvents.bulkAdd([
-			makePlayEvent(uri, Date.now() - 60000),
-			makePlayEvent(uri, Date.now()),
-		]);
+		await db.playEvents.bulkAdd([makePlayEvent(uri, Date.now() - 60000), makePlayEvent(uri, Date.now())]);
 		(Spicetify.Player as any).data = {
 			isPaused: false,
 			item: { uri, name: "Test Track", metadata: {} },

--- a/src/test/preferences.test.ts
+++ b/src/test/preferences.test.ts
@@ -103,10 +103,7 @@ describe("preferences", () => {
 		});
 
 		it("backfills playCountVariant default for pre-Phase-39 stored JSON", () => {
-			localStorage.setItem(
-				"listening-stats:preferences",
-				JSON.stringify({ use24HourTime: true, itemsPerSection: 10 }),
-			);
+			localStorage.setItem("listening-stats:preferences", JSON.stringify({ use24HourTime: true, itemsPerSection: 10 }));
 			const prefs = getPreferences();
 			expect(prefs.playCountVariant).toBe("pill");
 		});
@@ -122,12 +119,7 @@ describe("preferences", () => {
 
 	describe("stats.fm overview card ids", () => {
 		it("SFMC-01: OVERVIEW_CARD_IDS.statsfm canonical order (4 IDs  -  no streak/skip-rate)", () => {
-			expect(OVERVIEW_CARD_IDS.statsfm).toEqual([
-				"unique-artists",
-				"new-artists",
-				"top-genre",
-				"est-payout",
-			]);
+			expect(OVERVIEW_CARD_IDS.statsfm).toEqual(["unique-artists", "new-artists", "top-genre", "est-payout"]);
 		});
 
 		it("SFMC-01: OVERVIEW_CARD_IDS.statsfm contains est-payout (locked decision D-SFMC-01: retained)", () => {
@@ -161,12 +153,7 @@ describe("preferences", () => {
 				}),
 			);
 			const prefs = getPreferences();
-			expect(prefs.overviewOrder.statsfm).toEqual([
-				"unique-artists",
-				"est-payout",
-				"new-artists",
-				"top-genre",
-			]);
+			expect(prefs.overviewOrder.statsfm).toEqual(["unique-artists", "est-payout", "new-artists", "top-genre"]);
 			expect(prefs.overviewOrder.statsfm).not.toContain("listening-days");
 			expect(prefs.overviewOrder.statsfm).not.toContain("streak");
 			expect(prefs.overviewOrder.statsfm).not.toContain("skip-rate");
@@ -228,14 +215,7 @@ describe("preferences  -  v2.5 sectionOrder/columnOrder", () => {
 	});
 
 	it("persists sectionOrder via setPreference and round-trips", () => {
-		const custom = [
-			"recently-played",
-			"overview",
-			"top-lists",
-			"activity",
-			"top-genres",
-			"consistency",
-		];
+		const custom = ["recently-played", "overview", "top-lists", "activity", "top-genres", "consistency"];
 		setPreference("sectionOrder", custom);
 		expect(getPreferences().sectionOrder).toEqual(custom);
 	});
@@ -247,14 +227,7 @@ describe("preferences  -  v2.5 sectionOrder/columnOrder", () => {
 	});
 
 	it("preserves sectionOrder when setting an unrelated preference", () => {
-		const custom = [
-			"top-lists",
-			"overview",
-			"top-genres",
-			"activity",
-			"consistency",
-			"recently-played",
-		];
+		const custom = ["top-lists", "overview", "top-genres", "activity", "consistency", "recently-played"];
 		setPreference("sectionOrder", custom);
 		setPreference("use24HourTime", true);
 		const prefs = getPreferences();
@@ -316,26 +289,17 @@ describe("preferences hiddenSections normalization", () => {
 	});
 
 	it("PASSES THROUGH stored hiddenSections ['top-tracks'] unchanged (no collapse to ['top-lists'])", () => {
-		localStorage.setItem(
-			"listening-stats:preferences",
-			JSON.stringify({ hiddenSections: ["top-tracks"] }),
-		);
+		localStorage.setItem("listening-stats:preferences", JSON.stringify({ hiddenSections: ["top-tracks"] }));
 		expect(getPreferences().hiddenSections).toEqual(["top-tracks"]);
 	});
 
 	it("PASSES THROUGH stored hiddenSections ['top-artists'] unchanged", () => {
-		localStorage.setItem(
-			"listening-stats:preferences",
-			JSON.stringify({ hiddenSections: ["top-artists"] }),
-		);
+		localStorage.setItem("listening-stats:preferences", JSON.stringify({ hiddenSections: ["top-artists"] }));
 		expect(getPreferences().hiddenSections).toEqual(["top-artists"]);
 	});
 
 	it("PASSES THROUGH stored hiddenSections ['top-albums'] unchanged", () => {
-		localStorage.setItem(
-			"listening-stats:preferences",
-			JSON.stringify({ hiddenSections: ["top-albums"] }),
-		);
+		localStorage.setItem("listening-stats:preferences", JSON.stringify({ hiddenSections: ["top-albums"] }));
 		expect(getPreferences().hiddenSections).toEqual(["top-albums"]);
 	});
 
@@ -365,16 +329,11 @@ describe("preferences hiddenSections normalization", () => {
 
 	it("is idempotent on already-normalized list", () => {
 		const input = ["top-lists", "top-tracks"];
-		expect(normalizeHiddenSections(normalizeHiddenSections(input))).toEqual(
-			normalizeHiddenSections(input),
-		);
+		expect(normalizeHiddenSections(normalizeHiddenSections(input))).toEqual(normalizeHiddenSections(input));
 	});
 
 	it("does NOT write to localStorage on read", () => {
-		localStorage.setItem(
-			"listening-stats:preferences",
-			JSON.stringify({ hiddenSections: ["top-tracks"] }),
-		);
+		localStorage.setItem("listening-stats:preferences", JSON.stringify({ hiddenSections: ["top-tracks"] }));
 		// Read multiple times
 		getPreferences();
 		getPreferences();
@@ -404,10 +363,7 @@ describe("preferences overviewOrder", () => {
 	});
 
 	it("backfills overviewOrder for v2.4-shape stored JSON lacking the key", () => {
-		localStorage.setItem(
-			"listening-stats:preferences",
-			JSON.stringify({ use24HourTime: true, itemsPerSection: 10 }),
-		);
+		localStorage.setItem("listening-stats:preferences", JSON.stringify({ use24HourTime: true, itemsPerSection: 10 }));
 		const prefs = getPreferences();
 		expect(prefs.overviewOrder.local).toEqual([...OVERVIEW_CARD_IDS.local]);
 		expect(prefs.overviewOrder.statsfm).toEqual([...OVERVIEW_CARD_IDS.statsfm]);
@@ -415,15 +371,7 @@ describe("preferences overviewOrder", () => {
 
 	it("persists overviewOrder via setPreference and round-trips", () => {
 		const custom = {
-			local: [
-				"skip-rate",
-				"tracks",
-				"unique-artists",
-				"streak",
-				"new-artists",
-				"peak-hour",
-				"est-payout",
-			],
+			local: ["skip-rate", "tracks", "unique-artists", "streak", "new-artists", "peak-hour", "est-payout"],
 			statsfm: ["est-payout", "unique-artists", "new-artists", "top-genre"],
 		};
 		setPreference("overviewOrder", custom);
@@ -434,15 +382,7 @@ describe("preferences overviewOrder", () => {
 
 	it("setPreference overviewOrder preserves both provider arrays", () => {
 		const next = {
-			local: [
-				"streak",
-				"skip-rate",
-				"tracks",
-				"unique-artists",
-				"new-artists",
-				"peak-hour",
-				"est-payout",
-			],
+			local: ["streak", "skip-rate", "tracks", "unique-artists", "new-artists", "peak-hour", "est-payout"],
 			statsfm: ["top-genre", "est-payout", "unique-artists", "new-artists"],
 		};
 		setPreference("overviewOrder", next);
@@ -475,15 +415,7 @@ describe("preferences overviewOrder", () => {
 	});
 
 	it("reconciles overviewOrder.statsfm independently from local order", () => {
-		const customLocal = [
-			"skip-rate",
-			"tracks",
-			"unique-artists",
-			"streak",
-			"new-artists",
-			"peak-hour",
-			"est-payout",
-		];
+		const customLocal = ["skip-rate", "tracks", "unique-artists", "streak", "new-artists", "peak-hour", "est-payout"];
 		const customStatsfm = ["est-payout", "unique-artists", "new-artists", "top-genre"];
 		setPreference("overviewOrder", { local: customLocal, statsfm: customStatsfm });
 		const prefs = getPreferences();
@@ -513,12 +445,7 @@ describe("preferences overviewOrder", () => {
 	});
 
 	it("OVERVIEW_CARD_IDS.statsfm has four canonical tiles", () => {
-		expect(OVERVIEW_CARD_IDS.statsfm).toEqual([
-			"unique-artists",
-			"new-artists",
-			"top-genre",
-			"est-payout",
-		]);
+		expect(OVERVIEW_CARD_IDS.statsfm).toEqual(["unique-artists", "new-artists", "top-genre", "est-payout"]);
 		expect(OVERVIEW_CARD_IDS.statsfm.length).toBe(4);
 		expect(OVERVIEW_CARD_IDS.statsfm).not.toContain("peak-hour");
 		expect(OVERVIEW_CARD_IDS.statsfm).not.toContain("tracks");
@@ -565,12 +492,7 @@ describe("preferences overviewOrder", () => {
 			}),
 		);
 		const prefs = getPreferences();
-		expect(prefs.overviewOrder.statsfm).toEqual([
-			"unique-artists",
-			"top-genre",
-			"est-payout",
-			"new-artists",
-		]);
+		expect(prefs.overviewOrder.statsfm).toEqual(["unique-artists", "top-genre", "est-payout", "new-artists"]);
 		expect(prefs.overviewOrder.statsfm.length).toBe(4);
 	});
 
@@ -580,24 +502,12 @@ describe("preferences overviewOrder", () => {
 			JSON.stringify({
 				overviewOrder: {
 					local: [...OVERVIEW_CARD_IDS.local],
-					statsfm: [
-						"unique-artists",
-						"new-artists",
-						"top-genre",
-						"est-payout",
-						"streak",
-						"skip-rate",
-					],
+					statsfm: ["unique-artists", "new-artists", "top-genre", "est-payout", "streak", "skip-rate"],
 				},
 			}),
 		);
 		const prefs = getPreferences();
-		expect(prefs.overviewOrder.statsfm).toEqual([
-			"unique-artists",
-			"new-artists",
-			"top-genre",
-			"est-payout",
-		]);
+		expect(prefs.overviewOrder.statsfm).toEqual(["unique-artists", "new-artists", "top-genre", "est-payout"]);
 		expect(prefs.overviewOrder.statsfm).not.toContain("streak");
 		expect(prefs.overviewOrder.statsfm).not.toContain("skip-rate");
 	});
@@ -624,10 +534,7 @@ describe("preferences order reconciliation", () => {
 	});
 
 	it("sectionOrder: appends missing canonical ids at end in canonical order", () => {
-		localStorage.setItem(
-			"listening-stats:preferences",
-			JSON.stringify({ sectionOrder: ["overview", "top-lists"] }),
-		);
+		localStorage.setItem("listening-stats:preferences", JSON.stringify({ sectionOrder: ["overview", "top-lists"] }));
 		const prefs = getPreferences();
 		// stored order preserved for known ids, missing ones appended in canonical order
 		expect(prefs.sectionOrder).toEqual([

--- a/src/test/prefs-compat.test.ts
+++ b/src/test/prefs-compat.test.ts
@@ -1,16 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
-import {
-	getActivityMode,
-	getOverviewTilesForProvider,
-	getSectionsForProvider,
-} from "../app/capabilities";
-import {
-	COLUMN_IDS,
-	getPreferences,
-	OVERVIEW_CARD_IDS,
-	SECTION_IDS,
-	setPreference,
-} from "../app/preferences";
+import { getActivityMode, getOverviewTilesForProvider, getSectionsForProvider } from "../app/capabilities";
+import { COLUMN_IDS, getPreferences, OVERVIEW_CARD_IDS, SECTION_IDS, setPreference } from "../app/preferences";
 import type { ProviderCapabilities } from "../shared/stats/provider";
 
 const localCaps: ProviderCapabilities = {
@@ -107,29 +97,20 @@ describe("Preference migration/compat  -  pre-redesign preferences survive in re
 
 	it("v2.5 prefs with custom sectionOrder survive redesign", () => {
 		const customOrder = ["recently-played", "overview", "top-genres", "top-lists", "activity"];
-		localStorage.setItem(
-			"listening-stats:preferences",
-			JSON.stringify({ sectionOrder: customOrder }),
-		);
+		localStorage.setItem("listening-stats:preferences", JSON.stringify({ sectionOrder: customOrder }));
 		const prefs = getPreferences();
 		expect(prefs.sectionOrder).toEqual([...customOrder, "consistency"]);
 	});
 
 	it("v2.5 prefs with custom columnOrder survive redesign", () => {
 		const customOrder = ["top-albums", "top-artists", "top-tracks"];
-		localStorage.setItem(
-			"listening-stats:preferences",
-			JSON.stringify({ columnOrder: customOrder }),
-		);
+		localStorage.setItem("listening-stats:preferences", JSON.stringify({ columnOrder: customOrder }));
 		const prefs = getPreferences();
 		expect(prefs.columnOrder).toEqual(customOrder);
 	});
 
 	it("v2.5 prefs with hidden sections interact correctly with capability filtering", () => {
-		localStorage.setItem(
-			"listening-stats:preferences",
-			JSON.stringify({ hiddenSections: ["top-genres", "activity"] }),
-		);
+		localStorage.setItem("listening-stats:preferences", JSON.stringify({ hiddenSections: ["top-genres", "activity"] }));
 		const prefs = getPreferences();
 		const localSections = getSectionsForProvider(localCaps);
 		const visibleSections = prefs.sectionOrder.filter(
@@ -143,15 +124,7 @@ describe("Preference migration/compat  -  pre-redesign preferences survive in re
 	});
 
 	it("v2.5 prefs with custom overviewOrder survive redesign", () => {
-		const customLocal = [
-			"est-payout",
-			"tracks",
-			"unique-artists",
-			"streak",
-			"new-artists",
-			"peak-hour",
-			"skip-rate",
-		];
+		const customLocal = ["est-payout", "tracks", "unique-artists", "streak", "new-artists", "peak-hour", "skip-rate"];
 		const customStatsfm = ["top-genre", "unique-artists", "new-artists", "est-payout"];
 		localStorage.setItem(
 			"listening-stats:preferences",
@@ -163,13 +136,7 @@ describe("Preference migration/compat  -  pre-redesign preferences survive in re
 	});
 
 	it("prefs written via setPreference then read back are stable across round-trip", () => {
-		setPreference("sectionOrder", [
-			"top-lists",
-			"overview",
-			"recently-played",
-			"top-genres",
-			"activity",
-		]);
+		setPreference("sectionOrder", ["top-lists", "overview", "recently-played", "top-genres", "activity"]);
 		setPreference("hiddenSections", ["overview"]);
 		setPreference("use24HourTime", true);
 		const prefs = getPreferences();
@@ -197,15 +164,7 @@ describe("Preference migration/compat  -  capability + prefs integration for pro
 	});
 
 	it("switching from local to statsfm: overviewOrder.statsfm is independent of local", () => {
-		const customLocal = [
-			"skip-rate",
-			"tracks",
-			"unique-artists",
-			"streak",
-			"new-artists",
-			"peak-hour",
-			"est-payout",
-		];
+		const customLocal = ["skip-rate", "tracks", "unique-artists", "streak", "new-artists", "peak-hour", "est-payout"];
 		setPreference("overviewOrder", {
 			local: customLocal,
 			statsfm: [...OVERVIEW_CARD_IDS.statsfm],
@@ -227,9 +186,7 @@ describe("Preference migration/compat  -  capability + prefs integration for pro
 		const prefs = getPreferences();
 		const sections = getSectionsForProvider(statsfmFreeCaps);
 		const sectionIds = new Set(sections.map((s) => s.id));
-		const visible = prefs.sectionOrder.filter(
-			(id) => sectionIds.has(id) && !prefs.hiddenSections.includes(id),
-		);
+		const visible = prefs.sectionOrder.filter((id) => sectionIds.has(id) && !prefs.hiddenSections.includes(id));
 		expect(visible).toContain("overview");
 		expect(visible).toContain("top-lists");
 		expect(visible).toContain("recently-played");

--- a/src/test/progressive-loading.test.ts
+++ b/src/test/progressive-loading.test.ts
@@ -278,10 +278,7 @@ describe("StatsFmProvider.calculateStatsProgressive", () => {
 		await provider.init();
 		setupSfmGetDispatcher();
 
-		const progressiveResult = await provider.calculateStatsProgressive?.(
-			STATSFM_PERIODS[0],
-			() => {},
-		);
+		const progressiveResult = await provider.calculateStatsProgressive?.(STATSFM_PERIODS[0], () => {});
 
 		statsCache.invalidate();
 		sfmGetMock.mockClear();
@@ -303,18 +300,15 @@ describe("StatsFmProvider.calculateStatsProgressive", () => {
 			if (path.includes("/streams/stats/dates")) {
 				return Promise.resolve({ ok: false, status: 500, message: "Internal Server Error" });
 			}
-			if (path.includes("/top/tracks"))
-				return Promise.resolve({ ok: true, data: [makeSfmTopTrack()] });
-			if (path.includes("/top/artists"))
-				return Promise.resolve({ ok: true, data: [makeSfmTopArtist()] });
+			if (path.includes("/top/tracks")) return Promise.resolve({ ok: true, data: [makeSfmTopTrack()] });
+			if (path.includes("/top/artists")) return Promise.resolve({ ok: true, data: [makeSfmTopArtist()] });
 			if (path.includes("/top/genres")) return Promise.resolve({ ok: true, data: [] });
 			if (path.includes("/streams/stats/per-day"))
 				return Promise.resolve({
 					ok: true,
 					data: { average: { count: 0, durationMs: 0 }, days: {} },
 				});
-			if (path.includes("/streams/stats"))
-				return Promise.resolve({ ok: true, data: makeSfmStreamStats() });
+			if (path.includes("/streams/stats")) return Promise.resolve({ ok: true, data: makeSfmStreamStats() });
 			if (path.includes("/streams/recent")) return Promise.resolve({ ok: true, data: [] });
 			return Promise.resolve({ ok: false, status: 0, message: "skipped" });
 		});
@@ -386,10 +380,7 @@ describe("LocalProvider.calculateStatsProgressive", () => {
 			waveOrder.push(wave);
 		};
 
-		const result = await provider.calculateStatsProgressive?.(
-			provider.getSupportedPeriods()[0],
-			onWave,
-		);
+		const result = await provider.calculateStatsProgressive?.(provider.getSupportedPeriods()[0], onWave);
 
 		expect(waveOrder).toEqual([1, 2, 3]);
 		expect(result.totalPlays).toBe(0);
@@ -426,10 +417,8 @@ describe("generation counter stale-callback cancellation", () => {
 			if (path.includes("/streams/stats") && !path.includes("per-day") && !path.includes("dates")) {
 				return wave1Blocker.then(() => ({ ok: true, data: makeSfmStreamStats() }));
 			}
-			if (path.includes("/top/tracks"))
-				return Promise.resolve({ ok: true, data: [makeSfmTopTrack()] });
-			if (path.includes("/top/artists"))
-				return Promise.resolve({ ok: true, data: [makeSfmTopArtist()] });
+			if (path.includes("/top/tracks")) return Promise.resolve({ ok: true, data: [makeSfmTopTrack()] });
+			if (path.includes("/top/artists")) return Promise.resolve({ ok: true, data: [makeSfmTopArtist()] });
 			if (path.includes("/top/genres")) return Promise.resolve({ ok: true, data: [] });
 			if (path.includes("/streams/stats/per-day"))
 				return Promise.resolve({
@@ -496,18 +485,15 @@ describe("cache gating", () => {
 			if (path.includes("/streams/stats/dates")) {
 				return Promise.resolve({ ok: false, status: 500, message: "Server Error" });
 			}
-			if (path.includes("/top/tracks"))
-				return Promise.resolve({ ok: true, data: [makeSfmTopTrack()] });
-			if (path.includes("/top/artists"))
-				return Promise.resolve({ ok: true, data: [makeSfmTopArtist()] });
+			if (path.includes("/top/tracks")) return Promise.resolve({ ok: true, data: [makeSfmTopTrack()] });
+			if (path.includes("/top/artists")) return Promise.resolve({ ok: true, data: [makeSfmTopArtist()] });
 			if (path.includes("/top/genres")) return Promise.resolve({ ok: true, data: [] });
 			if (path.includes("/streams/stats/per-day"))
 				return Promise.resolve({
 					ok: true,
 					data: { average: { count: 0, durationMs: 0 }, days: {} },
 				});
-			if (path.includes("/streams/stats"))
-				return Promise.resolve({ ok: true, data: makeSfmStreamStats() });
+			if (path.includes("/streams/stats")) return Promise.resolve({ ok: true, data: makeSfmStreamStats() });
 			if (path.includes("/streams/recent")) return Promise.resolve({ ok: true, data: [] });
 			return Promise.resolve({ ok: false, status: 0, message: "skipped" });
 		});

--- a/src/test/progressive-loading.test.ts
+++ b/src/test/progressive-loading.test.ts
@@ -121,12 +121,10 @@ function setupSfmGetDispatcher() {
 			return Promise.resolve({
 				ok: true,
 				data: {
-					items: {
-						hours: { 14: { count: 38, durationMs: 0 }, 15: { count: 20, durationMs: 0 } },
-						weekDays: { 1: { count: 45, durationMs: 0 }, 6: { count: 112, durationMs: 0 } },
-						months: {},
-						years: {},
-					},
+					hours: { 14: { count: 38, durationMs: 0 }, 15: { count: 20, durationMs: 0 } },
+					weekDays: { 1: { count: 45, durationMs: 0 }, 6: { count: 112, durationMs: 0 } },
+					months: {},
+					years: {},
 				},
 			});
 		}
@@ -441,7 +439,7 @@ describe("generation counter stale-callback cancellation", () => {
 			if (path.includes("/streams/stats/dates"))
 				return Promise.resolve({
 					ok: true,
-					data: { items: { hours: {}, weekDays: {}, months: {}, years: {} } },
+					data: { hours: {}, weekDays: {}, months: {}, years: {} },
 				});
 			if (path.includes("/streams/recent")) return Promise.resolve({ ok: true, data: [] });
 			return Promise.resolve({ ok: false, status: 0, message: "skipped" });

--- a/src/test/provider-layout.test.ts
+++ b/src/test/provider-layout.test.ts
@@ -1,9 +1,5 @@
 import { describe, expect, it } from "vitest";
-import {
-	getActivityMode,
-	getOverviewTilesForProvider,
-	getSectionsForProvider,
-} from "../app/capabilities";
+import { getActivityMode, getOverviewTilesForProvider, getSectionsForProvider } from "../app/capabilities";
 import type { ProviderCapabilities } from "../shared/stats/provider";
 
 const localCaps: ProviderCapabilities = {
@@ -37,14 +33,7 @@ describe("Provider-specific layout  -  local provider renders a complete dashboa
 	it("local provider includes all 6 sections", () => {
 		const sections = getSectionsForProvider(localCaps);
 		const ids = sections.map((s) => s.id);
-		expect(ids).toEqual([
-			"overview",
-			"top-genres",
-			"top-lists",
-			"activity",
-			"consistency",
-			"recently-played",
-		]);
+		expect(ids).toEqual(["overview", "top-genres", "top-lists", "activity", "consistency", "recently-played"]);
 		expect(ids.length).toBe(6);
 	});
 

--- a/src/test/provider-layout.test.ts
+++ b/src/test/provider-layout.test.ts
@@ -16,7 +16,7 @@ const localCaps: ProviderCapabilities = {
 };
 
 const statsfmPlusCaps: ProviderCapabilities = {
-	hasActivityData: false,
+	hasActivityData: true,
 	hasConsistencyData: true,
 	hasGenreData: true,
 	hasStreakData: false,
@@ -25,7 +25,7 @@ const statsfmPlusCaps: ProviderCapabilities = {
 };
 
 const statsfmFreeCaps: ProviderCapabilities = {
-	hasActivityData: false,
+	hasActivityData: true,
 	hasConsistencyData: true,
 	hasGenreData: true,
 	hasStreakData: false,
@@ -73,18 +73,18 @@ describe("Provider-specific layout  -  local provider renders a complete dashboa
 });
 
 describe("Provider-specific layout  -  stats.fm free renders a reduced but coherent dashboard", () => {
-	it("stats.fm free excludes activity section (no activity data, not plus)", () => {
+	it("stats.fm free includes activity section (activity data available)", () => {
 		const sections = getSectionsForProvider(statsfmFreeCaps);
 		const ids = sections.map((s) => s.id);
-		expect(ids).not.toContain("activity");
+		expect(ids).toContain("activity");
 		expect(ids).toContain("consistency");
-		expect(ids.length).toBe(5);
+		expect(ids.length).toBe(6);
 	});
 
-	it("stats.fm free keeps overview, top-genres, top-lists, recently-played", () => {
+	it("stats.fm free keeps all sections including activity", () => {
 		const sections = getSectionsForProvider(statsfmFreeCaps);
 		const ids = sections.map((s) => s.id);
-		expect(ids).toEqual(["overview", "top-genres", "top-lists", "consistency", "recently-played"]);
+		expect(ids).toEqual(["overview", "top-genres", "top-lists", "activity", "consistency", "recently-played"]);
 	});
 
 	it("stats.fm free tiles include top-genre instead of peak-hour", () => {
@@ -94,7 +94,7 @@ describe("Provider-specific layout  -  stats.fm free renders a reduced but coher
 		expect(ids).not.toContain("peak-hour");
 	});
 
-	it("stats.fm free layout hides streak and skip-rate tiles", () => {
+	it("stats.fm free layout excludes streak and skip-rate", () => {
 		const tiles = getOverviewTilesForProvider("statsfm", statsfmFreeCaps);
 		const ids = tiles.map((t) => t.id);
 		expect(ids).not.toContain("streak");
@@ -111,21 +111,21 @@ describe("Provider-specific layout  -  stats.fm free renders a reduced but coher
 		expect(available).toContain("est-payout");
 	});
 
-	it("stats.fm free activity mode is 'hidden' (data not available from API)", () => {
-		expect(getActivityMode(statsfmFreeCaps)).toBe("hidden");
+	it("stats.fm free activity mode is 'full' (activity data available)", () => {
+		expect(getActivityMode(statsfmFreeCaps)).toBe("full");
 	});
 });
 
 describe("Provider-specific layout  -  stats.fm Plus renders a full dashboard with provider-specific tiles", () => {
-	it("stats.fm Plus excludes activity section (data not available from API)", () => {
+	it("stats.fm Plus includes activity section (activity data available)", () => {
 		const sections = getSectionsForProvider(statsfmPlusCaps);
 		const ids = sections.map((s) => s.id);
-		expect(ids).toEqual(["overview", "top-genres", "top-lists", "consistency", "recently-played"]);
-		expect(ids).not.toContain("activity");
+		expect(ids).toEqual(["overview", "top-genres", "top-lists", "activity", "consistency", "recently-played"]);
+		expect(ids).toContain("activity");
 	});
 
-	it("stats.fm Plus activity mode is 'hidden'", () => {
-		expect(getActivityMode(statsfmPlusCaps)).toBe("hidden");
+	it("stats.fm Plus activity mode is 'full'", () => {
+		expect(getActivityMode(statsfmPlusCaps)).toBe("full");
 	});
 
 	it("stats.fm Plus tiles include top-genre (not peak-hour)", () => {
@@ -135,7 +135,7 @@ describe("Provider-specific layout  -  stats.fm Plus renders a full dashboard wi
 		expect(ids).not.toContain("peak-hour");
 	});
 
-	it("stats.fm Plus layout hides streak tile", () => {
+	it("stats.fm Plus layout excludes streak and skip-rate", () => {
 		const tiles = getOverviewTilesForProvider("statsfm", statsfmPlusCaps);
 		const ids = tiles.map((t) => t.id);
 		expect(ids).not.toContain("streak");

--- a/src/test/providers-tab.test.ts
+++ b/src/test/providers-tab.test.ts
@@ -52,8 +52,7 @@ async function handleConnect(username: string) {
 	const result = await validateUsername(username.trim());
 	if (!result.valid) {
 		return {
-			error:
-				ERROR_MESSAGES[result.reason] ?? "Connection failed \u2014 check the console for details",
+			error: ERROR_MESSAGES[result.reason] ?? "Connection failed \u2014 check the console for details",
 		};
 	}
 

--- a/src/test/prune-obsolete-keys.test.ts
+++ b/src/test/prune-obsolete-keys.test.ts
@@ -16,9 +16,7 @@ describe("pruneObsoleteKeys", () => {
 		it("no entry in OBSOLETE_KEYS appears in LS_KEYS values", () => {
 			const activeKeys = new Set<string>(Object.values(LS_KEYS));
 			for (const key of OBSOLETE_KEYS) {
-				expect(activeKeys.has(key), `OBSOLETE_KEYS contains active LS_KEY value: ${key}`).toBe(
-					false,
-				);
+				expect(activeKeys.has(key), `OBSOLETE_KEYS contains active LS_KEY value: ${key}`).toBe(false);
 			}
 		});
 
@@ -54,10 +52,7 @@ describe("pruneObsoleteKeys", () => {
 
 		it("does NOT remove active LS_KEYS values when they are set", () => {
 			// Set a sample of active keys with realistic values
-			localStorage.setItem(
-				LS_KEYS.STATSFM_CONFIG,
-				JSON.stringify({ username: "test", isPlus: true }),
-			);
+			localStorage.setItem(LS_KEYS.STATSFM_CONFIG, JSON.stringify({ username: "test", isPlus: true }));
 			localStorage.setItem(LS_KEYS.PREFERENCES, JSON.stringify({ use24HourTime: true }));
 			localStorage.setItem(LS_KEYS.ACTIVE_PROVIDER, "statsfm");
 			localStorage.setItem(LS_KEYS.PROVIDER_PERIODS, JSON.stringify({ statsfm: "sfm-weeks" }));

--- a/src/test/segmented-control.test.ts
+++ b/src/test/segmented-control.test.ts
@@ -6,16 +6,12 @@ afterEach(() => {
 	cleanup();
 });
 
-const STOPS = [
-	0, 5000, 10000, 15000, 20000, 25000, 30000, 35000, 40000, 45000, 50000, 55000, 60000,
-];
+const STOPS = [0, 5000, 10000, 15000, 20000, 25000, 30000, 35000, 40000, 45000, 50000, 55000, 60000];
 
 describe("SegmentedControl", () => {
 	it("renders 13 stops", async () => {
 		const { SegmentedControl } = await import("../app/components/SegmentedControl");
-		const { container } = render(
-			React.createElement(SegmentedControl, { stops: STOPS, value: 0, onSelect: vi.fn() }),
-		);
+		const { container } = render(React.createElement(SegmentedControl, { stops: STOPS, value: 0, onSelect: vi.fn() }));
 		const stops = container.querySelectorAll(".segmented-control-stop");
 		expect(stops).toHaveLength(13);
 	});
@@ -33,9 +29,7 @@ describe("SegmentedControl", () => {
 	it("calls onSelect with the stop value when clicked", async () => {
 		const { SegmentedControl } = await import("../app/components/SegmentedControl");
 		const onSelect = vi.fn();
-		const { container } = render(
-			React.createElement(SegmentedControl, { stops: STOPS, value: 0, onSelect }),
-		);
+		const { container } = render(React.createElement(SegmentedControl, { stops: STOPS, value: 0, onSelect }));
 		const stops = container.querySelectorAll(".segmented-control-stop");
 		fireEvent.click(stops[6]); // 30000ms = 30s
 		expect(onSelect).toHaveBeenCalledWith(30000);
@@ -43,9 +37,7 @@ describe("SegmentedControl", () => {
 
 	it("renders the indicator element", async () => {
 		const { SegmentedControl } = await import("../app/components/SegmentedControl");
-		const { container } = render(
-			React.createElement(SegmentedControl, { stops: STOPS, value: 0, onSelect: vi.fn() }),
-		);
+		const { container } = render(React.createElement(SegmentedControl, { stops: STOPS, value: 0, onSelect: vi.fn() }));
 		const indicator = container.querySelector(".segmented-control-indicator");
 		expect(indicator).not.toBeNull();
 	});
@@ -64,9 +56,7 @@ describe("SegmentedControl", () => {
 
 	it("renders default labels as {val/1000}s", async () => {
 		const { SegmentedControl } = await import("../app/components/SegmentedControl");
-		const { container } = render(
-			React.createElement(SegmentedControl, { stops: STOPS, value: 0, onSelect: vi.fn() }),
-		);
+		const { container } = render(React.createElement(SegmentedControl, { stops: STOPS, value: 0, onSelect: vi.fn() }));
 		const stops = container.querySelectorAll(".segmented-control-stop");
 		expect(stops[0].textContent).toBe("0s");
 		expect(stops[1].textContent).toBe("5s");

--- a/src/test/settings-sync.test.tsx
+++ b/src/test/settings-sync.test.tsx
@@ -171,13 +171,7 @@ describe("Visible Sections drag-reorder persists sectionOrder + PREFS_CHANGED", 
 
 		const stored = JSON.parse(localStorage.getItem("listening-stats:preferences") ?? "{}");
 		expect(stored.sectionOrder).toBeDefined();
-		expect(stored.sectionOrder).not.toEqual([
-			"overview",
-			"top-genres",
-			"top-lists",
-			"activity",
-			"recently-played",
-		]);
+		expect(stored.sectionOrder).not.toEqual(["overview", "top-genres", "top-lists", "activity", "recently-played"]);
 		expect(stored.sectionOrder.indexOf("overview")).toBeGreaterThan(0); // overview moved down
 		expect(prefsChangedFired).toBeGreaterThanOrEqual(1);
 		expect(onPrefsChanged).toHaveBeenCalled();
@@ -219,15 +213,7 @@ describe("Visible Sections drag-reorder persists sectionOrder + PREFS_CHANGED", 
 		]);
 		setPreference("columnOrder", ["top-albums", "top-tracks", "top-artists"]);
 		setPreference("overviewOrder", {
-			local: [
-				"skip-rate",
-				"tracks",
-				"unique-artists",
-				"streak",
-				"new-artists",
-				"peak-hour",
-				"est-payout",
-			],
+			local: ["skip-rate", "tracks", "unique-artists", "streak", "new-artists", "peak-hour", "est-payout"],
 			statsfm: ["est-payout", "top-genre", "new-artists", "unique-artists"],
 		});
 
@@ -256,12 +242,7 @@ describe("Visible Sections drag-reorder persists sectionOrder + PREFS_CHANGED", 
 			"skip-rate",
 			"est-payout",
 		]);
-		expect(prefs.overviewOrder.statsfm).toEqual([
-			"unique-artists",
-			"new-artists",
-			"top-genre",
-			"est-payout",
-		]);
+		expect(prefs.overviewOrder.statsfm).toEqual(["unique-artists", "new-artists", "top-genre", "est-payout"]);
 	});
 
 	it("undo reset layout restores previous layout customization", () => {
@@ -385,9 +366,7 @@ describe("Top Lists Columns grid in DisplayTab", () => {
 
 		// The subsection wrapper should have opacity 0.4 and pointerEvents none
 		// Find by the data attribute we'll add on the wrapper
-		const subsection = document.querySelector<HTMLElement>(
-			'[data-testid="top-lists-columns-subsection"]',
-		);
+		const subsection = document.querySelector<HTMLElement>('[data-testid="top-lists-columns-subsection"]');
 		expect(subsection).not.toBeNull();
 		expect(subsection?.style.opacity).toBe("0.4");
 		expect(subsection?.style.pointerEvents).toBe("none");
@@ -550,20 +529,10 @@ describe("Overview Details grid in DisplayTab", () => {
 
 	it("renders 7 overview tiles split into top 4 (2x2) + bottom 3 (1x3) for local provider", () => {
 		renderFn(Spicetify.React.createElement(DisplayTab, { onPrefsChanged: () => {} }));
-		const tiles = document.querySelectorAll<HTMLElement>(
-			"[data-tile-id]:not([data-tile-id^='top-'])",
-		);
+		const tiles = document.querySelectorAll<HTMLElement>("[data-tile-id]:not([data-tile-id^='top-'])");
 		expect(tiles.length).toBe(7);
 		const ids = Array.from(tiles).map((t) => t.getAttribute("data-tile-id"));
-		expect(ids).toEqual([
-			"tracks",
-			"unique-artists",
-			"streak",
-			"new-artists",
-			"peak-hour",
-			"skip-rate",
-			"est-payout",
-		]);
+		expect(ids).toEqual(["tracks", "unique-artists", "streak", "new-artists", "peak-hour", "skip-rate", "est-payout"]);
 	});
 
 	it("local provider settings shows hero placeholder + 2x2 top grid + 1x3 bottom row", () => {

--- a/src/test/setup-wizard.test.ts
+++ b/src/test/setup-wizard.test.ts
@@ -1,11 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 // Imports that will exist after Task 2 (GREEN phase)
-import {
-	buildCacheKey,
-	buildProviderChangedState,
-	markWizardSeen,
-	shouldShowWizard,
-} from "../app/App";
+import { buildCacheKey, buildProviderChangedState, markWizardSeen, shouldShowWizard } from "../app/App";
 import { filterOverviewCards } from "../app/components/OverviewCards";
 import { LS_KEYS } from "../shared/constants/storage-keys";
 import { providerRegistry } from "../shared/stats/provider";

--- a/src/test/share-export.test.ts
+++ b/src/test/share-export.test.ts
@@ -195,39 +195,21 @@ describe("renderShareCardBlob (Canvas 2D pipeline)", () => {
 
 	it("produces a PNG blob", async () => {
 		const { renderShareCardBlob } = await import("../app/components/ShareModal");
-		const blob = await renderShareCardBlob(
-			makeMockStats(),
-			"top5",
-			"square",
-			"Last 4 weeks",
-			"testuser",
-		);
+		const blob = await renderShareCardBlob(makeMockStats(), "top5", "square", "Last 4 weeks", "testuser");
 		expect(blob).toBeInstanceOf(Blob);
 		expect(blob.type).toBe("image/png");
 	});
 
 	it("creates canvas with correct dimensions for square", async () => {
 		const { renderShareCardCanvas } = await import("../app/components/ShareModal");
-		const canvas = await renderShareCardCanvas(
-			makeMockStats(),
-			"top5",
-			"square",
-			"Last 4 weeks",
-			"",
-		);
+		const canvas = await renderShareCardCanvas(makeMockStats(), "top5", "square", "Last 4 weeks", "");
 		expect(canvas.width).toBe(1080);
 		expect(canvas.height).toBe(1080);
 	});
 
 	it("creates canvas with correct dimensions for story", async () => {
 		const { renderShareCardCanvas } = await import("../app/components/ShareModal");
-		const canvas = await renderShareCardCanvas(
-			makeMockStats(),
-			"top5",
-			"story",
-			"Last 4 weeks",
-			"",
-		);
+		const canvas = await renderShareCardCanvas(makeMockStats(), "top5", "story", "Last 4 weeks", "");
 		expect(canvas.width).toBe(1080);
 		expect(canvas.height).toBe(1920);
 	});
@@ -244,13 +226,7 @@ describe("renderShareCardBlob (Canvas 2D pipeline)", () => {
 
 	it("renders wrapped variant in story size without error", async () => {
 		const { renderShareCardBlob } = await import("../app/components/ShareModal");
-		const blob = await renderShareCardBlob(
-			makeMockStats(),
-			"wrapped",
-			"story",
-			"Last 4 weeks",
-			"testuser",
-		);
+		const blob = await renderShareCardBlob(makeMockStats(), "wrapped", "story", "Last 4 weeks", "testuser");
 		expect(blob).toBeInstanceOf(Blob);
 	});
 
@@ -302,13 +278,11 @@ describe("exportShareCardPng", () => {
 
 		const clickSpy = vi.fn();
 		const origCE = document.createElement.bind(document);
-		vi.spyOn(document, "createElement").mockImplementation(
-			(tag: string, opts?: ElementCreationOptions) => {
-				const node = origCE.call(document, tag, opts);
-				if (tag === "a") vi.spyOn(node, "click").mockImplementation(clickSpy);
-				return node;
-			},
-		);
+		vi.spyOn(document, "createElement").mockImplementation((tag: string, opts?: ElementCreationOptions) => {
+			const node = origCE.call(document, tag, opts);
+			if (tag === "a") vi.spyOn(node, "click").mockImplementation(clickSpy);
+			return node;
+		});
 
 		await exportShareCardPng(makeMockStats(), "top5", "square", "Last 4 weeks", "");
 
@@ -359,9 +333,9 @@ describe("copyShareCardToClipboard", () => {
 			configurable: true,
 		});
 
-		await expect(
-			copyShareCardToClipboard(makeMockStats(), "top5", "square", "Last 4 weeks", ""),
-		).rejects.toThrow("Clipboard API not available");
+		await expect(copyShareCardToClipboard(makeMockStats(), "top5", "square", "Last 4 weeks", "")).rejects.toThrow(
+			"Clipboard API not available",
+		);
 	});
 });
 
@@ -432,13 +406,11 @@ describe("shareOrDownload", () => {
 
 		const clickSpy = vi.fn();
 		const origCE = document.createElement.bind(document);
-		vi.spyOn(document, "createElement").mockImplementation(
-			(tag: string, opts?: ElementCreationOptions) => {
-				const node = origCE.call(document, tag, opts);
-				if (tag === "a") vi.spyOn(node, "click").mockImplementation(clickSpy);
-				return node;
-			},
-		);
+		vi.spyOn(document, "createElement").mockImplementation((tag: string, opts?: ElementCreationOptions) => {
+			const node = origCE.call(document, tag, opts);
+			if (tag === "a") vi.spyOn(node, "click").mockImplementation(clickSpy);
+			return node;
+		});
 
 		const blob = new Blob(["png"], { type: "image/png" });
 		const result = await shareOrDownload(blob);
@@ -495,9 +467,7 @@ describe("ShareModal busy state", () => {
 		);
 
 		const copyBtn = document.querySelector<HTMLButtonElement>("[data-testid='share-copy-btn']");
-		const downloadBtn = document.querySelector<HTMLButtonElement>(
-			"[data-testid='share-download-btn']",
-		);
+		const downloadBtn = document.querySelector<HTMLButtonElement>("[data-testid='share-download-btn']");
 		expect(copyBtn).toBeTruthy();
 		expect(downloadBtn).toBeTruthy();
 		expect(copyBtn?.disabled).toBe(false);
@@ -555,9 +525,7 @@ describe("ShareModal busy state", () => {
 			container,
 		);
 
-		const downloadBtn = document.querySelector<HTMLButtonElement>(
-			"[data-testid='share-download-btn']",
-		);
+		const downloadBtn = document.querySelector<HTMLButtonElement>("[data-testid='share-download-btn']");
 		downloadBtn?.click();
 
 		await vi.waitFor(() => {

--- a/src/test/share-modal.test.tsx
+++ b/src/test/share-modal.test.tsx
@@ -113,12 +113,8 @@ describe("ShareModal", () => {
 	it("renders modal chrome and action buttons", async () => {
 		const { container } = await renderShareModal();
 		expect(document.querySelector(".share-modal")).toBeTruthy();
-		expect(document.querySelector("[data-testid='share-copy-btn']")?.textContent).toContain(
-			"Copy image",
-		);
-		expect(document.querySelector("[data-testid='share-download-btn']")?.textContent).toContain(
-			"Save PNG",
-		);
+		expect(document.querySelector("[data-testid='share-copy-btn']")?.textContent).toContain("Copy image");
+		expect(document.querySelector("[data-testid='share-download-btn']")?.textContent).toContain("Save PNG");
 		Spicetify.ReactDOM.unmountComponentAtNode(container);
 		container.remove();
 	});
@@ -134,9 +130,7 @@ describe("ShareModal", () => {
 
 	it("shows follow theme toggle", async () => {
 		const { container } = await renderShareModal();
-		const toggle = document.querySelector<HTMLInputElement>(
-			".share-toggle-row input[type='checkbox']",
-		);
+		const toggle = document.querySelector<HTMLInputElement>(".share-toggle-row input[type='checkbox']");
 		expect(toggle).toBeTruthy();
 		expect(toggle?.checked).toBe(false);
 		toggle?.click();
@@ -148,9 +142,7 @@ describe("ShareModal", () => {
 	it("hides streak variant for statsfm provider", async () => {
 		providerRegistry.setActive("statsfm");
 		const { container } = await renderShareModal();
-		const labels = Array.from(document.querySelectorAll(".share-variant-tab")).map((t) =>
-			t.textContent?.trim(),
-		);
+		const labels = Array.from(document.querySelectorAll(".share-variant-tab")).map((t) => t.textContent?.trim());
 		expect(labels).not.toContain("Streak");
 		Spicetify.ReactDOM.unmountComponentAtNode(container);
 		container.remove();
@@ -159,9 +151,7 @@ describe("ShareModal", () => {
 	it("hides genre variant for local provider", async () => {
 		providerRegistry.setActive("local");
 		const { container } = await renderShareModal();
-		const labels = Array.from(document.querySelectorAll(".share-variant-tab")).map((t) =>
-			t.textContent?.trim(),
-		);
+		const labels = Array.from(document.querySelectorAll(".share-variant-tab")).map((t) => t.textContent?.trim());
 		expect(labels).not.toContain("Genre");
 		Spicetify.ReactDOM.unmountComponentAtNode(container);
 		container.remove();

--- a/src/test/stats-cache.test.ts
+++ b/src/test/stats-cache.test.ts
@@ -133,9 +133,7 @@ describe("StatsProvider interface (type-level checks)", () => {
 
 	it("ProviderRegistry setActive throws when provider not registered", () => {
 		const registry = new ProviderRegistry();
-		expect(() => registry.setActive("nonexistent")).toThrow(
-			'Provider "nonexistent" not registered',
-		);
+		expect(() => registry.setActive("nonexistent")).toThrow('Provider "nonexistent" not registered');
 	});
 
 	it("ProviderRegistry getAll returns ProviderInfo for all registered providers", () => {

--- a/src/test/statsfm-client.test.ts
+++ b/src/test/statsfm-client.test.ts
@@ -1,11 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { circuitBreaker } from "../shared/api/circuit-breaker";
-import {
-	type StatsFmHealthPayload,
-	sfmCircuitBreaker,
-	sfmGet,
-	validateUsername,
-} from "../shared/api/statsfm-client";
+import { type StatsFmHealthPayload, sfmCircuitBreaker, sfmGet, validateUsername } from "../shared/api/statsfm-client";
 
 // Helper to build a fake fetch Response
 function makeResponse(status: number, body: unknown = null): Response {

--- a/src/test/statsfm-provider.test.ts
+++ b/src/test/statsfm-provider.test.ts
@@ -136,12 +136,10 @@ function setupSfmGetDispatcher(isPlus = false) {
 			return Promise.resolve({
 				ok: true,
 				data: {
-					items: {
-						hours: { 14: { count: 38, durationMs: 0 }, 15: { count: 20, durationMs: 0 } },
-						weekDays: { 1: { count: 45, durationMs: 0 }, 6: { count: 112, durationMs: 0 } },
-						months: {},
-						years: {},
-					},
+					hours: { 14: { count: 38, durationMs: 0 }, 15: { count: 20, durationMs: 0 } },
+					weekDays: { 1: { count: 45, durationMs: 0 }, 6: { count: 112, durationMs: 0 } },
+					months: {},
+					years: {},
 				},
 			});
 		}
@@ -718,15 +716,14 @@ describe("StatsFmProvider", () => {
 			expect(result.peakHour).toBe(0);
 		});
 
-		it("calculateStats result does not include streak field (streak is undefined)", async () => {
+		it("calculateStats result includes streak computed from per-day data", async () => {
 			setupConfig({ isPlus: false });
 			await provider.init();
 			setupSfmGetDispatcher(false);
 
 			const result = await provider.calculateStats(STATSFM_PERIODS[0]);
 
-			// stats.fm payload omits streak
-			expect(result.streak).toBeUndefined();
+			expect(result.streak).toBe(2);
 		});
 
 		it("requests prior-window /top/artists and derives newArtistCount from Spotify URI diff", async () => {
@@ -794,7 +791,7 @@ describe("StatsFmProvider", () => {
 			// No config in localStorage  -  init() leaves this.config null
 			await provider.init();
 			const info = provider.getProviderInfo();
-			expect(info.capabilities.hasActivityData).toBe(false);
+			expect(info.capabilities.hasActivityData).toBe(true);
 			expect(info.capabilities.hasGenreData).toBe(true);
 			expect(info.capabilities.hasStreakData).toBe(false);
 			expect(info.capabilities.hasSkipRate).toBe(false);
@@ -813,7 +810,7 @@ describe("StatsFmProvider", () => {
 			);
 			await provider.init();
 			const info = provider.getProviderInfo();
-			expect(info.capabilities.hasActivityData).toBe(false);
+			expect(info.capabilities.hasActivityData).toBe(true);
 			expect(info.capabilities.hasGenreData).toBe(true);
 			expect(info.capabilities.hasStreakData).toBe(false);
 			expect(info.capabilities.hasSkipRate).toBe(false);
@@ -832,7 +829,7 @@ describe("StatsFmProvider", () => {
 			);
 			await provider.init();
 			const info = provider.getProviderInfo();
-			expect(info.capabilities.hasActivityData).toBe(false);
+			expect(info.capabilities.hasActivityData).toBe(true);
 			expect(info.capabilities.hasGenreData).toBe(true);
 			expect(info.capabilities.hasStreakData).toBe(false);
 			expect(info.capabilities.hasSkipRate).toBe(false);
@@ -943,7 +940,7 @@ describe("StatsFmProvider", () => {
 				if (path.includes("/streams/stats/dates"))
 					return Promise.resolve({
 						ok: true,
-						data: { items: { hours: {}, weekDays: {}, months: {}, years: {} } },
+						data: { hours: {}, weekDays: {}, months: {}, years: {} },
 					});
 				if (path.includes("/streams/stats"))
 					return Promise.resolve({ ok: true, data: makeSfmStreamStats() });

--- a/src/test/statsfm-provider.test.ts
+++ b/src/test/statsfm-provider.test.ts
@@ -304,9 +304,7 @@ describe("StatsFmProvider", () => {
 	describe("calculateStats()", () => {
 		it("throws Error when config is null (provider not configured)", async () => {
 			const period = STATSFM_PERIODS[0];
-			await expect(provider.calculateStats(period)).rejects.toThrow(
-				"StatsFmProvider not configured",
-			);
+			await expect(provider.calculateStats(period)).rejects.toThrow("StatsFmProvider not configured");
 		});
 
 		it("calls sfmGet for /top/tracks, /top/artists, /top/genres, /streams/stats, /streams/recent", async () => {
@@ -334,9 +332,7 @@ describe("StatsFmProvider", () => {
 			await provider.calculateStats(period);
 
 			// All calls should use range param, not after/before
-			const callWithRange = sfmGetMock.mock.calls.find(
-				(c) => c[1] && "range" in (c[1] as Record<string, string>),
-			);
+			const callWithRange = sfmGetMock.mock.calls.find((c) => c[1] && "range" in (c[1] as Record<string, string>));
 			expect(callWithRange).toBeDefined();
 			const params = callWithRange?.[1] as Record<string, string>;
 			expect(params.range).toBe("weeks");
@@ -353,9 +349,7 @@ describe("StatsFmProvider", () => {
 			const allTimePeriod = STATSFM_PERIODS[2]; // sfm-all-time
 			await provider.calculateStats(allTimePeriod);
 
-			const callWithRange = sfmGetMock.mock.calls.find(
-				(c) => c[1] && "range" in (c[1] as Record<string, string>),
-			);
+			const callWithRange = sfmGetMock.mock.calls.find((c) => c[1] && "range" in (c[1] as Record<string, string>));
 			expect(callWithRange).toBeDefined();
 			const params = callWithRange?.[1] as Record<string, string>;
 			expect(params.range).toBe("lifetime");
@@ -390,11 +384,9 @@ describe("StatsFmProvider", () => {
 					t.track.externalIds = { spotify: undefined };
 					return Promise.resolve({ ok: true, data: [t] });
 				}
-				if (path.includes("/top/artists"))
-					return Promise.resolve({ ok: true, data: [makeSfmTopArtist()] });
+				if (path.includes("/top/artists")) return Promise.resolve({ ok: true, data: [makeSfmTopArtist()] });
 				if (path.includes("/top/genres")) return Promise.resolve({ ok: true, data: [] });
-				if (path.includes("/streams/stats"))
-					return Promise.resolve({ ok: true, data: makeSfmStreamStats() });
+				if (path.includes("/streams/stats")) return Promise.resolve({ ok: true, data: makeSfmStreamStats() });
 				if (path.includes("/streams/recent")) return Promise.resolve({ ok: true, data: [] });
 				return Promise.resolve({ ok: false, status: 0, message: "skipped" });
 			});
@@ -495,13 +487,10 @@ describe("StatsFmProvider", () => {
 			track3.track.albums[0].name = "Solo Album";
 
 			sfmGetMock.mockImplementation((path: string) => {
-				if (path.includes("/top/tracks"))
-					return Promise.resolve({ ok: true, data: [track1, track2, track3] });
-				if (path.includes("/top/artists"))
-					return Promise.resolve({ ok: true, data: [makeSfmTopArtist()] });
+				if (path.includes("/top/tracks")) return Promise.resolve({ ok: true, data: [track1, track2, track3] });
+				if (path.includes("/top/artists")) return Promise.resolve({ ok: true, data: [makeSfmTopArtist()] });
 				if (path.includes("/top/genres")) return Promise.resolve({ ok: true, data: [] });
-				if (path.includes("/streams/stats"))
-					return Promise.resolve({ ok: true, data: makeSfmStreamStats() });
+				if (path.includes("/streams/stats")) return Promise.resolve({ ok: true, data: makeSfmStreamStats() });
 				if (path.includes("/streams/recent")) return Promise.resolve({ ok: true, data: [] });
 				return Promise.resolve({ ok: false, status: 0, message: "skipped" });
 			});
@@ -547,13 +536,10 @@ describe("StatsFmProvider", () => {
 			artist2.artist.genres = ["pop", "jazz"];
 
 			sfmGetMock.mockImplementation((path: string) => {
-				if (path.includes("/top/tracks"))
-					return Promise.resolve({ ok: true, data: [makeSfmTopTrack()] });
-				if (path.includes("/top/artists"))
-					return Promise.resolve({ ok: true, data: [artist1, artist2] });
+				if (path.includes("/top/tracks")) return Promise.resolve({ ok: true, data: [makeSfmTopTrack()] });
+				if (path.includes("/top/artists")) return Promise.resolve({ ok: true, data: [artist1, artist2] });
 				if (path.includes("/top/genres")) return Promise.resolve({ ok: true, data: [] });
-				if (path.includes("/streams/stats"))
-					return Promise.resolve({ ok: true, data: makeSfmStreamStats() });
+				if (path.includes("/streams/stats")) return Promise.resolve({ ok: true, data: makeSfmStreamStats() });
 				if (path.includes("/streams/recent")) return Promise.resolve({ ok: true, data: [] });
 				return Promise.resolve({ ok: false, status: 0, message: "skipped" });
 			});
@@ -602,16 +588,11 @@ describe("StatsFmProvider", () => {
 			await provider.init();
 
 			sfmGetMock.mockImplementation((path: string) => {
-				if (path.includes("/top/tracks"))
-					return Promise.resolve({ ok: false, status: 500, message: "error" });
-				if (path.includes("/top/artists"))
-					return Promise.resolve({ ok: false, status: 500, message: "error" });
-				if (path.includes("/top/genres"))
-					return Promise.resolve({ ok: false, status: 500, message: "error" });
-				if (path.includes("/streams/stats"))
-					return Promise.resolve({ ok: false, status: 500, message: "error" });
-				if (path.includes("/streams/recent"))
-					return Promise.resolve({ ok: false, status: 500, message: "error" });
+				if (path.includes("/top/tracks")) return Promise.resolve({ ok: false, status: 500, message: "error" });
+				if (path.includes("/top/artists")) return Promise.resolve({ ok: false, status: 500, message: "error" });
+				if (path.includes("/top/genres")) return Promise.resolve({ ok: false, status: 500, message: "error" });
+				if (path.includes("/streams/stats")) return Promise.resolve({ ok: false, status: 500, message: "error" });
+				if (path.includes("/streams/recent")) return Promise.resolve({ ok: false, status: 500, message: "error" });
 				return Promise.resolve({ ok: false, status: 0, message: "skipped" });
 			});
 
@@ -675,10 +656,8 @@ describe("StatsFmProvider", () => {
 					return Promise.resolve({ ok: false, status: 403, message: "Plus required" });
 				}
 				// Delegate to default dispatcher for other paths
-				if (path.includes("/top/tracks"))
-					return Promise.resolve({ ok: true, data: [makeSfmTopTrack()] });
-				if (path.includes("/top/artists"))
-					return Promise.resolve({ ok: true, data: [makeSfmTopArtist()] });
+				if (path.includes("/top/tracks")) return Promise.resolve({ ok: true, data: [makeSfmTopTrack()] });
+				if (path.includes("/top/artists")) return Promise.resolve({ ok: true, data: [makeSfmTopArtist()] });
 				if (path.includes("/top/genres"))
 					return Promise.resolve({
 						ok: true,
@@ -692,8 +671,7 @@ describe("StatsFmProvider", () => {
 							days: { "2026-03-28T00:00:00.000Z": { count: 5, durationMs: 900000 } },
 						},
 					});
-				if (path.includes("/streams/stats"))
-					return Promise.resolve({ ok: true, data: makeSfmStreamStats() });
+				if (path.includes("/streams/stats")) return Promise.resolve({ ok: true, data: makeSfmStreamStats() });
 				if (path.includes("/streams/recent"))
 					return Promise.resolve({
 						ok: true,
@@ -705,8 +683,7 @@ describe("StatsFmProvider", () => {
 							},
 						],
 					});
-				if (path.includes("/top/albums"))
-					return Promise.resolve({ ok: false, status: 400, message: "Free tier" });
+				if (path.includes("/top/albums")) return Promise.resolve({ ok: false, status: 400, message: "Free tier" });
 				return Promise.resolve({ ok: false, status: 404, message: "Unknown path" });
 			});
 			const result = await provider.calculateStats(STATSFM_PERIODS[0]);
@@ -758,12 +735,8 @@ describe("StatsFmProvider", () => {
 			const result = await provider.calculateStats(allTime);
 
 			// No /top/artists call should have been made with after/before params
-			const allCalls = sfmGetMock.mock.calls.filter(([path]) =>
-				String(path).includes("/top/artists"),
-			);
-			const priorCalls = allCalls.filter(
-				([_, params]) => params && "after" in params && "before" in params,
-			);
+			const allCalls = sfmGetMock.mock.calls.filter(([path]) => String(path).includes("/top/artists"));
+			const priorCalls = allCalls.filter(([_, params]) => params && "after" in params && "before" in params);
 			expect(priorCalls.length).toBe(0);
 
 			expect(result.newArtistCount).toBe(0);
@@ -928,10 +901,8 @@ describe("StatsFmProvider", () => {
 				if (path.includes("/top/genres")) {
 					return Promise.resolve({ ok: false, status: 500, message: "HTTP 500" });
 				}
-				if (path.includes("/top/tracks"))
-					return Promise.resolve({ ok: true, data: [makeSfmTopTrack()] });
-				if (path.includes("/top/artists"))
-					return Promise.resolve({ ok: true, data: [makeSfmTopArtist()] });
+				if (path.includes("/top/tracks")) return Promise.resolve({ ok: true, data: [makeSfmTopTrack()] });
+				if (path.includes("/top/artists")) return Promise.resolve({ ok: true, data: [makeSfmTopArtist()] });
 				if (path.includes("/streams/stats/per-day"))
 					return Promise.resolve({
 						ok: true,
@@ -942,8 +913,7 @@ describe("StatsFmProvider", () => {
 						ok: true,
 						data: { hours: {}, weekDays: {}, months: {}, years: {} },
 					});
-				if (path.includes("/streams/stats"))
-					return Promise.resolve({ ok: true, data: makeSfmStreamStats() });
+				if (path.includes("/streams/stats")) return Promise.resolve({ ok: true, data: makeSfmStreamStats() });
 				if (path.includes("/streams/recent")) return Promise.resolve({ ok: true, data: [] });
 				return Promise.resolve({ ok: false, status: 0, message: "skipped" });
 			});

--- a/src/test/top-genres.test.ts
+++ b/src/test/top-genres.test.ts
@@ -27,10 +27,7 @@ describe("TopGenres component", () => {
 
 	it("renders .section-card wrapper with 'Top Genres' heading when topGenres has items", async () => {
 		const { TopGenres } = await import("../app/components/TopGenres");
-		Spicetify.ReactDOM.render(
-			Spicetify.React.createElement(TopGenres, { topGenres: mockGenres }),
-			container,
-		);
+		Spicetify.ReactDOM.render(Spicetify.React.createElement(TopGenres, { topGenres: mockGenres }), container);
 		const card = container.querySelector(".section-card");
 		expect(card).not.toBeNull();
 		expect(card?.textContent).toContain("Top Genres");
@@ -38,10 +35,7 @@ describe("TopGenres component", () => {
 
 	it("renders kicker 'Composition' and title 'Top Genres'", async () => {
 		const { TopGenres } = await import("../app/components/TopGenres");
-		Spicetify.ReactDOM.render(
-			Spicetify.React.createElement(TopGenres, { topGenres: mockGenres }),
-			container,
-		);
+		Spicetify.ReactDOM.render(Spicetify.React.createElement(TopGenres, { topGenres: mockGenres }), container);
 		const kicker = container.querySelector(".section-kicker");
 		expect(kicker?.textContent).toBe("Composition");
 		const title = container.querySelector(".section-title");
@@ -50,39 +44,27 @@ describe("TopGenres component", () => {
 
 	it("renders nothing (null) when topGenres is empty array", async () => {
 		const { TopGenres } = await import("../app/components/TopGenres");
-		Spicetify.ReactDOM.render(
-			Spicetify.React.createElement(TopGenres, { topGenres: [] }),
-			container,
-		);
+		Spicetify.ReactDOM.render(Spicetify.React.createElement(TopGenres, { topGenres: [] }), container);
 		expect(container.innerHTML).toBe("");
 	});
 
 	it("renders max 6 .top-genres-row elements (design spec)", async () => {
 		const { TopGenres } = await import("../app/components/TopGenres");
-		Spicetify.ReactDOM.render(
-			Spicetify.React.createElement(TopGenres, { topGenres: manyGenres }),
-			container,
-		);
+		Spicetify.ReactDOM.render(Spicetify.React.createElement(TopGenres, { topGenres: manyGenres }), container);
 		const rows = container.querySelectorAll(".top-genres-row");
 		expect(rows.length).toBe(6);
 	});
 
 	it("first genre bar has .peak class", async () => {
 		const { TopGenres } = await import("../app/components/TopGenres");
-		Spicetify.ReactDOM.render(
-			Spicetify.React.createElement(TopGenres, { topGenres: mockGenres }),
-			container,
-		);
+		Spicetify.ReactDOM.render(Spicetify.React.createElement(TopGenres, { topGenres: mockGenres }), container);
 		const bars = container.querySelectorAll(".top-genres-bar");
 		expect(bars[0]?.classList.contains("peak")).toBe(true);
 	});
 
 	it("non-first genre bars do NOT have .peak class", async () => {
 		const { TopGenres } = await import("../app/components/TopGenres");
-		Spicetify.ReactDOM.render(
-			Spicetify.React.createElement(TopGenres, { topGenres: mockGenres }),
-			container,
-		);
+		Spicetify.ReactDOM.render(Spicetify.React.createElement(TopGenres, { topGenres: mockGenres }), container);
 		const bars = container.querySelectorAll(".top-genres-bar");
 		expect(bars[1]?.classList.contains("peak")).toBe(false);
 		expect(bars[2]?.classList.contains("peak")).toBe(false);
@@ -90,30 +72,21 @@ describe("TopGenres component", () => {
 
 	it("bar width of rank-1 genre is '100%'", async () => {
 		const { TopGenres } = await import("../app/components/TopGenres");
-		Spicetify.ReactDOM.render(
-			Spicetify.React.createElement(TopGenres, { topGenres: mockGenres }),
-			container,
-		);
+		Spicetify.ReactDOM.render(Spicetify.React.createElement(TopGenres, { topGenres: mockGenres }), container);
 		const bars = container.querySelectorAll<HTMLElement>(".top-genres-bar");
 		expect(bars[0]?.style.width).toBe("100%");
 	});
 
 	it("bar width proportional  -  genre with half the count of max gets '50%' width", async () => {
 		const { TopGenres } = await import("../app/components/TopGenres");
-		Spicetify.ReactDOM.render(
-			Spicetify.React.createElement(TopGenres, { topGenres: mockGenres }),
-			container,
-		);
+		Spicetify.ReactDOM.render(Spicetify.React.createElement(TopGenres, { topGenres: mockGenres }), container);
 		const bars = container.querySelectorAll<HTMLElement>(".top-genres-bar");
 		expect(bars[1]?.style.width).toBe("50%");
 	});
 
 	it("genre name displayed in .top-genres-name button, percentage in .top-genres-pct", async () => {
 		const { TopGenres } = await import("../app/components/TopGenres");
-		Spicetify.ReactDOM.render(
-			Spicetify.React.createElement(TopGenres, { topGenres: mockGenres }),
-			container,
-		);
+		Spicetify.ReactDOM.render(Spicetify.React.createElement(TopGenres, { topGenres: mockGenres }), container);
 		const names = container.querySelectorAll(".top-genres-name");
 		const pcts = container.querySelectorAll(".top-genres-pct");
 		expect(names[0]?.textContent).toBe("pop");

--- a/src/test/toplists-integration.test.ts
+++ b/src/test/toplists-integration.test.ts
@@ -278,9 +278,7 @@ describe("TopLists section headings", () => {
 	it("Tracks column renders section-heading with kicker 'Most played' and title 'Tracks'", async () => {
 		const { TopLists } = await import("../app/components/TopLists");
 		const stats = makeStats({ topTracks: [makeTrack()] });
-		const { container } = render(
-			React.createElement(TopLists, { stats, loading: false, hiddenSections: [] }),
-		);
+		const { container } = render(React.createElement(TopLists, { stats, loading: false, hiddenSections: [] }));
 		const tracksCard = container.querySelector('[data-column-id="top-tracks"]');
 		expect(tracksCard).not.toBeNull();
 		const heading = tracksCard?.querySelector(".section-heading");
@@ -292,9 +290,7 @@ describe("TopLists section headings", () => {
 	it("Artists column renders section-heading with kicker 'Top' and title 'Artists'", async () => {
 		const { TopLists } = await import("../app/components/TopLists");
 		const stats = makeStats({ topArtists: [makeArtist()] });
-		const { container } = render(
-			React.createElement(TopLists, { stats, loading: false, hiddenSections: [] }),
-		);
+		const { container } = render(React.createElement(TopLists, { stats, loading: false, hiddenSections: [] }));
 		const artistsCard = container.querySelector('[data-column-id="top-artists"]');
 		expect(artistsCard).not.toBeNull();
 		const heading = artistsCard?.querySelector(".section-heading");
@@ -318,9 +314,7 @@ describe("TopLists section headings", () => {
 				},
 			],
 		});
-		const { container } = render(
-			React.createElement(TopLists, { stats, loading: false, hiddenSections: [] }),
-		);
+		const { container } = render(React.createElement(TopLists, { stats, loading: false, hiddenSections: [] }));
 		const albumsCard = container.querySelector('[data-column-id="top-albums"]');
 		expect(albumsCard).not.toBeNull();
 		const heading = albumsCard?.querySelector(".section-heading");

--- a/src/test/tracker-fsm.test.ts
+++ b/src/test/tracker-fsm.test.ts
@@ -181,9 +181,7 @@ describe("TrackingFSM", () => {
 			nowSpy.mockRestore();
 			// Now change song  -  should write with type='play'
 			await fsm2.handleSongChange(makePlayerData({ uri: "spotify:track:B", durationMs: 180000 }));
-			expect(
-				(deps.addPlayEvent as ReturnType<typeof vi.fn>).mock.calls.length,
-			).toBeGreaterThanOrEqual(0);
+			expect((deps.addPlayEvent as ReturnType<typeof vi.fn>).mock.calls.length).toBeGreaterThanOrEqual(0);
 		});
 
 		it("classifies as 'skip' when totalPlayedMs < threshold and durationMs > threshold", async () => {
@@ -197,14 +195,10 @@ describe("TrackingFSM", () => {
 				getPlayThreshold: vi.fn(() => 30000),
 			});
 			// Start tracking with durationMs = 180000 (> threshold)
-			await fsmSkip.handleSongChange(
-				makePlayerData({ uri: "spotify:track:A", durationMs: 180000 }),
-			);
+			await fsmSkip.handleSongChange(makePlayerData({ uri: "spotify:track:A", durationMs: 180000 }));
 			// Don't accumulate any play time  -  immediately change song
 			// Total played will be very small (< 30s)
-			await fsmSkip.handleSongChange(
-				makePlayerData({ uri: "spotify:track:B", durationMs: 180000 }),
-			);
+			await fsmSkip.handleSongChange(makePlayerData({ uri: "spotify:track:B", durationMs: 180000 }));
 			// The event was written  -  check it was a skip (total played is near 0ms)
 			expect(capturedType).toBe("skip");
 		});
@@ -313,16 +307,12 @@ describe("TrackingFSM", () => {
 			const skipFsm = new TrackingFSM(skipDeps);
 
 			// Play track A twice
-			await skipFsm.handleSongChange(
-				makePlayerData({ uri: "spotify:track:A", durationMs: 180000 }),
-			);
+			await skipFsm.handleSongChange(makePlayerData({ uri: "spotify:track:A", durationMs: 180000 }));
 			// Make it look like a play (wait long enough or advance time)
 			const spy = vi.spyOn(Date, "now").mockReturnValue(Date.now() + 35000);
 			skipFsm.handlePlayPause(true); // bank 35s
 			spy.mockRestore();
-			await skipFsm.handleSongChange(
-				makePlayerData({ uri: "spotify:track:A", durationMs: 180000 }),
-			); // same track
+			await skipFsm.handleSongChange(makePlayerData({ uri: "spotify:track:A", durationMs: 180000 })); // same track
 			// First play writes
 			expect(skipDeps.addPlayEvent as ReturnType<typeof vi.fn>).toHaveBeenCalledTimes(1);
 
@@ -330,9 +320,7 @@ describe("TrackingFSM", () => {
 			const spy2 = vi.spyOn(Date, "now").mockReturnValue(Date.now() + 35000);
 			skipFsm.handlePlayPause(true);
 			spy2.mockRestore();
-			await skipFsm.handleSongChange(
-				makePlayerData({ uri: "spotify:track:B", durationMs: 180000 }),
-			);
+			await skipFsm.handleSongChange(makePlayerData({ uri: "spotify:track:B", durationMs: 180000 }));
 			// Second consecutive write for track A should be suppressed
 			// (if lastRecordedUri === track:A and same URI again is attempted)
 			// In this case track A -> track A suppresses on second write attempt

--- a/src/test/tracker-init.test.ts
+++ b/src/test/tracker-init.test.ts
@@ -564,9 +564,7 @@ describe("tracker/index integrity and versionchange wiring", () => {
 		// Invoke the captured callback  -  verifies it calls health.recordFailure
 		expect(capturedVersionChangeCallback).toBeDefined();
 		capturedVersionChangeCallback?.();
-		expect(recordFailureSpy).toHaveBeenCalledWith(
-			"DB connection closed  -  version upgrade in another tab",
-		);
+		expect(recordFailureSpy).toHaveBeenCalledWith("DB connection closed  -  version upgrade in another tab");
 	});
 
 	it("wrappedAddPlayEvent sets LAST_WRITE in localStorage on successful write", async () => {
@@ -722,8 +720,6 @@ describe("extension/index  -  init timeout (poll timeout at 30s)", () => {
 		vi.advanceTimersByTime(200);
 
 		// No timeout error
-		expect(consoleErrorSpy).not.toHaveBeenCalledWith(
-			expect.stringContaining("Player API not found"),
-		);
+		expect(consoleErrorSpy).not.toHaveBeenCalledWith(expect.stringContaining("Player API not found"));
 	});
 });

--- a/src/test/update-remote.test.ts
+++ b/src/test/update-remote.test.ts
@@ -20,9 +20,7 @@ describe("compareVersions", () => {
 
 describe("markdownLiteToHtml", () => {
 	it("renders headings, bold, links, and code", () => {
-		const html = markdownLiteToHtml(
-			"## Title\n\nHello **world** and `code` and [a](https://ex.test).",
-		);
+		const html = markdownLiteToHtml("## Title\n\nHello **world** and `code` and [a](https://ex.test).");
 		expect(html).toContain("<h3>");
 		expect(html).toContain("Title");
 		expect(html).toContain("<strong>world</strong>");

--- a/src/test/uri-resolver.test.ts
+++ b/src/test/uri-resolver.test.ts
@@ -201,9 +201,7 @@ describe("resolveImportedUris", () => {
 		const event2 = events.find((e) => e.trackUri === "listening-stats:track:uri2");
 		expect(event2).toBeDefined();
 		// Second event was never resolved (circuit stopped it)
-		expect(
-			event2?.resolvedAt === null || event2?.resolvedAt === undefined || event2?.resolvedAt === 0,
-		).toBe(true);
+		expect(event2?.resolvedAt === null || event2?.resolvedAt === undefined || event2?.resolvedAt === 0).toBe(true);
 	});
 
 	it("Test 5 (batch update - same synthetic URI): 3 events same URI results in 1 search, all updated", async () => {
@@ -386,8 +384,6 @@ describe("resolveImportedUris", () => {
 		await resolveImportedUris({ delayMs: 0 });
 
 		// Verify cosmosGet was called with encoded URL
-		expect(cosmosGetMock).toHaveBeenCalledWith(
-			expect.stringContaining(encodeURIComponent("Don't Stop Me Now")),
-		);
+		expect(cosmosGetMock).toHaveBeenCalledWith(expect.stringContaining(encodeURIComponent("Don't Stop Me Now")));
 	});
 });

--- a/src/test/use-settings-sortable.test.ts
+++ b/src/test/use-settings-sortable.test.ts
@@ -43,9 +43,7 @@ describe("useSettingsSortable", () => {
 		const onReorder = vi.fn();
 		const { result } = renderHook(() => useSettingsSortable({ order: ["a", "b", "c"], onReorder }));
 		act(() => {
-			result.current.onItemPointerDown("a")(
-				new PointerEvent("pointerdown", { clientX: 0, clientY: 0 }),
-			);
+			result.current.onItemPointerDown("a")(new PointerEvent("pointerdown", { clientX: 0, clientY: 0 }));
 		});
 		act(() => {
 			window.dispatchEvent(new PointerEvent("pointermove", { clientX: 0, clientY: 5 }));
@@ -58,9 +56,7 @@ describe("useSettingsSortable", () => {
 		const onReorder = vi.fn();
 		const { result } = renderHook(() => useSettingsSortable({ order: ["a", "b", "c"], onReorder }));
 		act(() => {
-			result.current.onItemPointerDown("a")(
-				new PointerEvent("pointerdown", { clientX: 0, clientY: 0 }),
-			);
+			result.current.onItemPointerDown("a")(new PointerEvent("pointerdown", { clientX: 0, clientY: 0 }));
 		});
 		act(() => {
 			window.dispatchEvent(new PointerEvent("pointermove", { clientX: 0, clientY: 10 }));
@@ -73,9 +69,7 @@ describe("useSettingsSortable", () => {
 		const onReorder = vi.fn();
 		const { result } = renderHook(() => useSettingsSortable({ order: ["a", "b", "c"], onReorder }));
 		act(() => {
-			result.current.onItemPointerDown("a")(
-				new PointerEvent("pointerdown", { clientX: 0, clientY: 0 }),
-			);
+			result.current.onItemPointerDown("a")(new PointerEvent("pointerdown", { clientX: 0, clientY: 0 }));
 		});
 		act(() => {
 			window.dispatchEvent(new PointerEvent("pointermove", { clientX: 0, clientY: 20 }));
@@ -99,9 +93,7 @@ describe("useSettingsSortable", () => {
 		});
 		// Start drag
 		act(() => {
-			result.current.onItemPointerDown("a")(
-				new PointerEvent("pointerdown", { clientX: 50, clientY: 0 }),
-			);
+			result.current.onItemPointerDown("a")(new PointerEvent("pointerdown", { clientX: 50, clientY: 0 }));
 		});
 		// Move 10px to activate drag, pointer at y=50 (in item b's range)
 		act(() => {
@@ -134,9 +126,7 @@ describe("useSettingsSortable", () => {
 		});
 		// Start drag
 		act(() => {
-			result.current.onItemPointerDown("a")(
-				new PointerEvent("pointerdown", { clientX: 0, clientY: 20 }),
-			);
+			result.current.onItemPointerDown("a")(new PointerEvent("pointerdown", { clientX: 0, clientY: 20 }));
 		});
 		// Move 10px to activate, pointer at x=50 (in b range)
 		act(() => {
@@ -158,13 +148,9 @@ describe("useSettingsSortable", () => {
 
 	it("applies translate3d on Y axis when orientation='vertical'", () => {
 		const onReorder = vi.fn();
-		const { result } = renderHook(() =>
-			useSettingsSortable({ order: ["a", "b"], onReorder, orientation: "vertical" }),
-		);
+		const { result } = renderHook(() => useSettingsSortable({ order: ["a", "b"], onReorder, orientation: "vertical" }));
 		act(() => {
-			result.current.onItemPointerDown("a")(
-				new PointerEvent("pointerdown", { clientX: 0, clientY: 0 }),
-			);
+			result.current.onItemPointerDown("a")(new PointerEvent("pointerdown", { clientX: 0, clientY: 0 }));
 		});
 		act(() => {
 			window.dispatchEvent(new PointerEvent("pointermove", { clientX: 5, clientY: 20 }));
@@ -181,9 +167,7 @@ describe("useSettingsSortable", () => {
 			useSettingsSortable({ order: ["a", "b"], onReorder, orientation: "horizontal" }),
 		);
 		act(() => {
-			result.current.onItemPointerDown("a")(
-				new PointerEvent("pointerdown", { clientX: 0, clientY: 0 }),
-			);
+			result.current.onItemPointerDown("a")(new PointerEvent("pointerdown", { clientX: 0, clientY: 0 }));
 		});
 		act(() => {
 			window.dispatchEvent(new PointerEvent("pointermove", { clientX: 20, clientY: 5 }));
@@ -203,9 +187,7 @@ describe("useSettingsSortable", () => {
 		});
 		// Start drag on "a"
 		act(() => {
-			result.current.onItemPointerDown("a")(
-				new PointerEvent("pointerdown", { clientX: 0, clientY: 0 }),
-			);
+			result.current.onItemPointerDown("a")(new PointerEvent("pointerdown", { clientX: 0, clientY: 0 }));
 		});
 		// Move to activate + position over slot 2 (pointer y=90 → > c's midline at 100? no, 90<100 so slot 2)
 		act(() => {
@@ -231,9 +213,7 @@ describe("useSettingsSortable", () => {
 		});
 		// Drag "a" but keep pointer in slot 0 (y < a midline 20)
 		act(() => {
-			result.current.onItemPointerDown("a")(
-				new PointerEvent("pointerdown", { clientX: 0, clientY: 0 }),
-			);
+			result.current.onItemPointerDown("a")(new PointerEvent("pointerdown", { clientX: 0, clientY: 0 }));
 		});
 		act(() => {
 			window.dispatchEvent(new PointerEvent("pointermove", { clientX: 0, clientY: 10 }));
@@ -249,9 +229,7 @@ describe("useSettingsSortable", () => {
 		const onReorder = vi.fn();
 		const { result } = renderHook(() => useSettingsSortable({ order: ["a", "b", "c"], onReorder }));
 		act(() => {
-			result.current.onItemPointerDown("a")(
-				new PointerEvent("pointerdown", { clientX: 0, clientY: 0 }),
-			);
+			result.current.onItemPointerDown("a")(new PointerEvent("pointerdown", { clientX: 0, clientY: 0 }));
 		});
 		act(() => {
 			window.dispatchEvent(new PointerEvent("pointermove", { clientX: 0, clientY: 10 }));
@@ -269,9 +247,7 @@ describe("useSettingsSortable", () => {
 		const onReorder = vi.fn();
 		const { result } = renderHook(() => useSettingsSortable({ order: ["a", "b", "c"], onReorder }));
 		act(() => {
-			result.current.onItemPointerDown("a")(
-				new PointerEvent("pointerdown", { clientX: 0, clientY: 0 }),
-			);
+			result.current.onItemPointerDown("a")(new PointerEvent("pointerdown", { clientX: 0, clientY: 0 }));
 		});
 		act(() => {
 			window.dispatchEvent(new PointerEvent("pointermove", { clientX: 0, clientY: 10 }));
@@ -290,9 +266,7 @@ describe("useSettingsSortable", () => {
 		const { result } = renderHook(() => useSettingsSortable({ order: ["b", "c"], onReorder }));
 		// Try to start drag with "a" which is NOT in order
 		act(() => {
-			result.current.onItemPointerDown("a")(
-				new PointerEvent("pointerdown", { clientX: 0, clientY: 0 }),
-			);
+			result.current.onItemPointerDown("a")(new PointerEvent("pointerdown", { clientX: 0, clientY: 0 }));
 		});
 		act(() => {
 			window.dispatchEvent(new PointerEvent("pointermove", { clientX: 0, clientY: 20 }));
@@ -304,15 +278,7 @@ describe("useSettingsSortable", () => {
 
 	it("grid orientation handles seven-tile overview order arrays", () => {
 		const onReorder = vi.fn();
-		const sevenIds = [
-			"tracks",
-			"unique-artists",
-			"streak",
-			"new-artists",
-			"peak-hour",
-			"skip-rate",
-			"est-payout",
-		];
+		const sevenIds = ["tracks", "unique-artists", "streak", "new-artists", "peak-hour", "skip-rate", "est-payout"];
 		const { result } = renderHook(() =>
 			useSettingsSortable({
 				order: sevenIds,
@@ -341,9 +307,7 @@ describe("useSettingsSortable", () => {
 
 		// Begin a drag on est-payout (last tile).
 		act(() => {
-			result.current.onItemPointerDown("est-payout")(
-				new PointerEvent("pointerdown", { clientX: 270, clientY: 70 }),
-			);
+			result.current.onItemPointerDown("est-payout")(new PointerEvent("pointerdown", { clientX: 270, clientY: 70 }));
 		});
 
 		// Move pointer to the first row, first tile area.

--- a/src/test/v1-compat.test.ts
+++ b/src/test/v1-compat.test.ts
@@ -228,9 +228,7 @@ describe("v1 compatibility migration retry flag", () => {
 		// Close db so initDatabase has work to do
 		db.close();
 
-		const openSpy = vi
-			.spyOn(db, "open")
-			.mockRejectedValueOnce(new Error("simulated upgrade failure"));
+		const openSpy = vi.spyOn(db, "open").mockRejectedValueOnce(new Error("simulated upgrade failure"));
 
 		try {
 			await initDatabase();

--- a/src/test/world-charts-async.test.ts
+++ b/src/test/world-charts-async.test.ts
@@ -12,12 +12,7 @@ vi.mock("../app/world-charts-service", async (importOriginal) => {
 });
 
 import type { WorldChartResult } from "../app/world-charts-service";
-import {
-	getArtistChartsAsync,
-	getChartsAsync,
-	WORLD_ARTISTS,
-	WORLD_TRACKS,
-} from "../app/world-charts-service";
+import { getArtistChartsAsync, getChartsAsync, WORLD_ARTISTS, WORLD_TRACKS } from "../app/world-charts-service";
 import type { WorldTrack } from "../shared/types/world-charts";
 
 const getChartsAsyncMock = vi.mocked(getChartsAsync);

--- a/src/test/world-charts-service.test.ts
+++ b/src/test/world-charts-service.test.ts
@@ -70,10 +70,7 @@ describe("getChartsAsync", () => {
 	});
 
 	it("falls back to WORLD_TRACKS when fetch fails", async () => {
-		const fetchMock = vi
-			.fn()
-			.mockRejectedValueOnce(new Error("network"))
-			.mockRejectedValueOnce(new Error("network"));
+		const fetchMock = vi.fn().mockRejectedValueOnce(new Error("network")).mockRejectedValueOnce(new Error("network"));
 		vi.stubGlobal("fetch", fetchMock);
 
 		const { getChartsAsync, WORLD_TRACKS } = await import("../app/world-charts-service");

--- a/src/test/world-charts.test.ts
+++ b/src/test/world-charts.test.ts
@@ -181,9 +181,7 @@ describe("WorldChartsPage  -  click-to-search", () => {
 		const { container } = await renderAndWaitForLoad();
 		const items = container.querySelectorAll(".world-chart-item");
 		fireEvent.click(items[0]);
-		expect(Spicetify.Platform.History.push).toHaveBeenCalledWith(
-			expect.stringContaining("/search/"),
-		);
+		expect(Spicetify.Platform.History.push).toHaveBeenCalledWith(expect.stringContaining("/search/"));
 	});
 });
 


### PR DESCRIPTION
- Fix SfmDateStats API data access (remove double items unwrap)
- Normalize per-day API dates to YYYY-MM-DD for heatmap compatibility
- Display streak in Consistency section as green-accented metric card
- Remove streak from Overview (now shown in Consistency)
- Rename Activity tabs: By weekday -> By week, By day -> By month
- Round tops of activity bar charts (border-radius: 6px)
- Update all tests to match new behavior (1188 passing)

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Enhancement / improvement
- [ ] Documentation
- [ ] Refactor (no functional change)
- [ ] Other (describe below)

## How to Test

1. `npm install && npm run build`
2. Deploy to Spicetify: `npm run deploy`
3. Open Listening Stats in Spotify sidebar
4. Switch to stats.fm provider, enable Streak toggle in Settings
5. Check Consistency section for green streak card
6. Check Activity > By month for CalendarHeatmap

## Checklist

- [x] Tested locally with `npm run build` (no errors)
- [x] Tested in Spotify with Spicetify applied
- [x] Changes work with all providers (Local / stats.fm / Last.fm) if applicable
- [x] No sensitive data (API keys, tokens) included in the code
<img width="2492" height="692" alt="Bildschirmfoto_20260516_181814" src="https://github.com/user-attachments/assets/1b5d6e00-24ba-4483-a604-277d255ade82" />

