### PR TITLE
Bugfix/statsfm null genres export

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "listening-stats",
-	"version": "2.0.0",
+	"version": "2.0.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "listening-stats",
-			"version": "2.0.0",
+			"version": "2.0.1",
 			"dependencies": {
 				"dexie": "^4.4.2",
 				"fflate": "^0.8.2",

--- a/src/app/components/settings/DataTab.tsx
+++ b/src/app/components/settings/DataTab.tsx
@@ -130,8 +130,11 @@ export function DataTab({ onRefresh }: Props) {
 
 	const handleExportJson = async () => {
 		try {
-			const allTimePeriod = LOCAL_PERIODS[4];
-			const stats = await providerRegistry.getActive()?.calculateStats(allTimePeriod);
+			const activeProvider = providerRegistry.getActive();
+			const allTimePeriod = activeProvider?.getSupportedPeriods().find(
+				(p) => p.id.endsWith("all-time") || p.label === "All Time",
+			) ?? LOCAL_PERIODS[4];
+			const stats = await activeProvider?.calculateStats(allTimePeriod);
 			if (!stats) {
 				Spicetify.showNotification("No active provider", true);
 				return;
@@ -145,8 +148,11 @@ export function DataTab({ onRefresh }: Props) {
 
 	const handleExportCsv = async () => {
 		try {
-			const allTimePeriod = LOCAL_PERIODS[4];
-			const stats = await providerRegistry.getActive()?.calculateStats(allTimePeriod);
+			const activeProvider = providerRegistry.getActive();
+			const allTimePeriod = activeProvider?.getSupportedPeriods().find(
+				(p) => p.id.endsWith("all-time") || p.label === "All Time",
+			) ?? LOCAL_PERIODS[4];
+			const stats = await activeProvider?.calculateStats(allTimePeriod);
 			if (!stats) {
 				Spicetify.showNotification("No active provider", true);
 				return;

--- a/src/app/components/settings/DataTab.tsx
+++ b/src/app/components/settings/DataTab.tsx
@@ -126,9 +126,9 @@ export function DataTab({ onRefresh }: Props) {
 	const handleExportJson = async () => {
 		try {
 			const activeProvider = providerRegistry.getActive();
-			const allTimePeriod = activeProvider?.getSupportedPeriods().find(
-				(p) => p.id.endsWith("all-time") || p.label === "All Time",
-			) ?? LOCAL_PERIODS[4];
+			const allTimePeriod =
+				activeProvider?.getSupportedPeriods().find((p) => p.id.endsWith("all-time") || p.label === "All Time") ??
+				LOCAL_PERIODS[4];
 			const stats = await activeProvider?.calculateStats(allTimePeriod);
 			if (!stats) {
 				Spicetify.showNotification("No active provider", true);
@@ -144,9 +144,9 @@ export function DataTab({ onRefresh }: Props) {
 	const handleExportCsv = async () => {
 		try {
 			const activeProvider = providerRegistry.getActive();
-			const allTimePeriod = activeProvider?.getSupportedPeriods().find(
-				(p) => p.id.endsWith("all-time") || p.label === "All Time",
-			) ?? LOCAL_PERIODS[4];
+			const allTimePeriod =
+				activeProvider?.getSupportedPeriods().find((p) => p.id.endsWith("all-time") || p.label === "All Time") ??
+				LOCAL_PERIODS[4];
 			const stats = await activeProvider?.calculateStats(allTimePeriod);
 			if (!stats) {
 				Spicetify.showNotification("No active provider", true);

--- a/src/shared/stats/statsfm-provider.ts
+++ b/src/shared/stats/statsfm-provider.ts
@@ -102,31 +102,47 @@ function extractFailure(
 }
 
 function genresFromArtists(artists: SfmTopArtist[]): TopGenre[] {
-	const genreCount = new Map<string, number>();
+	// Weighted: multiply each genre occurrence by ta.streams
+	const weighted = new Map<string, number>();
 	for (const ta of artists) {
 		for (const genre of ta.artist.genres) {
-			genreCount.set(genre, (genreCount.get(genre) ?? 0) + ta.streams);
+			weighted.set(genre, (weighted.get(genre) ?? 0) + (+(ta.streams ?? 0)));
 		}
 	}
-	return Array.from(genreCount.entries())
+	const hasWeight = [...weighted.values()].some((c) => c > 0);
+	if (hasWeight) {
+		return Array.from(weighted.entries())
+			.sort((a, b) => b[1] - a[1])
+			.map(([genre, count], i) => ({ rank: i + 1, genre, count }));
+	}
+	// Fallback: unweighted (1 per artist per genre) when streams are missing/zero
+	const unweighted = new Map<string, number>();
+	for (const ta of artists) {
+		for (const genre of ta.artist.genres) {
+			unweighted.set(genre, (unweighted.get(genre) ?? 0) + 1);
+		}
+	}
+	return Array.from(unweighted.entries())
 		.sort((a, b) => b[1] - a[1])
 		.map(([genre, count], i) => ({ rank: i + 1, genre, count }));
 }
 
-/** Prefer stats.fm `/top/genres` when the API returns rows (works even when artist.genres[] is empty). */
+/** Prefer stats.fm `/top/genres` when the API returns rows with non-zero counts (works even when artist.genres[] is empty). */
 function topGenresFromApiOrArtists(
 	apiRows: SfmTopGenre[] | null | undefined,
 	artists: SfmTopArtist[],
 ): TopGenre[] {
 	const rows = apiRows ?? [];
 	if (rows.length > 0) {
-		return [...rows]
+		const mapped = [...rows]
 			.sort((a, b) => b.streams - a.streams)
 			.map((g, i) => ({
 				rank: i + 1,
 				genre: g.genre.tag,
-				count: g.streams,
+				count: +(g.streams ?? 0),
 			}));
+		const totalCount = mapped.reduce((s, g) => s + g.count, 0);
+		if (totalCount > 0) return mapped;
 	}
 	return genresFromArtists(artists);
 }
@@ -150,15 +166,16 @@ function deriveAlbumsFromTracks(tracks: SfmTopTrack[]): TopAlbum[] {
 		const existing = albumMap.get(key);
 		const artistName = tt.track.artists[0]?.name ?? "";
 		const albumUri = prefixUri(album.externalIds?.spotify?.[0], "album") ?? "";
+		const streams = tt.streams ?? 0;
 		if (existing) {
-			existing.streams += tt.streams;
+			existing.streams += streams;
 		} else {
 			albumMap.set(key, {
 				albumName: album.name,
 				artistName,
 				albumArt: album.image,
 				albumUri,
-				streams: tt.streams,
+				streams,
 			});
 		}
 	}
@@ -372,22 +389,25 @@ export class StatsFmProvider implements StatsProvider {
 		}
 
 		// Map tracks
-		const topTracks: TopTrack[] = tracks.map((tt) => ({
-			rank: tt.position,
-			trackUri:
-				prefixUri(tt.track.externalIds?.spotify?.[0], "track") ??
-				`listening-stats:track:${tt.track.name}${tt.track.artists[0]?.name ?? ""}`,
-			trackName: tt.track.name,
-			artistName: tt.track.artists[0]?.name ?? "",
-			artistUri:
-				prefixUri(tt.track.artists[0]?.externalIds?.spotify?.[0], "artist") ??
-				`listening-stats:artist:${tt.track.artists[0]?.name ?? ""}`,
-			albumName: tt.track.albums[0]?.name ?? "",
-			albumUri: prefixUri(tt.track.albums[0]?.externalIds?.spotify?.[0], "album") ?? "",
-			albumArt: tt.track.albums[0]?.image,
-			count: tt.streams,
-			durationMs: tt.track.durationMs * tt.streams,
-		}));
+		const topTracks: TopTrack[] = tracks.map((tt) => {
+			const streams = tt.streams ?? 0;
+			return {
+				rank: tt.position,
+				trackUri:
+					prefixUri(tt.track.externalIds?.spotify?.[0], "track") ??
+					`listening-stats:track:${tt.track.name}${tt.track.artists[0]?.name ?? ""}`,
+				trackName: tt.track.name,
+				artistName: tt.track.artists[0]?.name ?? "",
+				artistUri:
+					prefixUri(tt.track.artists[0]?.externalIds?.spotify?.[0], "artist") ??
+					`listening-stats:artist:${tt.track.artists[0]?.name ?? ""}`,
+				albumName: tt.track.albums[0]?.name ?? "",
+				albumUri: prefixUri(tt.track.albums[0]?.externalIds?.spotify?.[0], "album") ?? "",
+				albumArt: tt.track.albums[0]?.image,
+				count: streams,
+				durationMs: tt.track.durationMs * streams,
+			};
+		});
 
 		// Genres from stats.fm artist payload (no extra Spotify batch here)
 		const topArtists: TopArtist[] = artists.map((ta) => ({
@@ -396,7 +416,7 @@ export class StatsFmProvider implements StatsProvider {
 				prefixUri(ta.artist.externalIds?.spotify?.[0], "artist") ??
 				`listening-stats:artist:${ta.artist.name}`,
 			artistName: ta.artist.name,
-			count: ta.streams,
+			count: ta.streams ?? 0,
 			durationMs: ta.playedMs ?? 0,
 			genres: ta.artist.genres,
 			imageUrl: ta.artist.image ?? null,
@@ -412,7 +432,7 @@ export class StatsFmProvider implements StatsProvider {
 					albumName: ab.album.name,
 					artistName: ab.album.artists[0]?.name ?? "",
 					albumArt: ab.album.image,
-					count: ab.streams,
+					count: ab.streams ?? 0,
 					durationMs: 0,
 				}))
 			: deriveAlbumsFromTracks(tracks);
@@ -597,22 +617,25 @@ export class StatsFmProvider implements StatsProvider {
 		const wave2Tasks: Promise<void>[] = [
 			tracksPromise.then((res) => {
 				tracks = res.ok ? res.data : [];
-				topTracks = tracks.map((tt) => ({
-					rank: tt.position,
-					trackUri:
-						prefixUri(tt.track.externalIds?.spotify?.[0], "track") ??
-						`listening-stats:track:${tt.track.name}${tt.track.artists[0]?.name ?? ""}`,
-					trackName: tt.track.name,
-					artistName: tt.track.artists[0]?.name ?? "",
-					artistUri:
-						prefixUri(tt.track.artists[0]?.externalIds?.spotify?.[0], "artist") ??
-						`listening-stats:artist:${tt.track.artists[0]?.name ?? ""}`,
-					albumName: tt.track.albums[0]?.name ?? "",
-					albumUri: prefixUri(tt.track.albums[0]?.externalIds?.spotify?.[0], "album") ?? "",
-					albumArt: tt.track.albums[0]?.image,
-					count: tt.streams,
-					durationMs: tt.track.durationMs * tt.streams,
-				}));
+				topTracks = tracks.map((tt) => {
+					const streams = tt.streams ?? 0;
+					return {
+						rank: tt.position,
+						trackUri:
+							prefixUri(tt.track.externalIds?.spotify?.[0], "track") ??
+							`listening-stats:track:${tt.track.name}${tt.track.artists[0]?.name ?? ""}`,
+						trackName: tt.track.name,
+						artistName: tt.track.artists[0]?.name ?? "",
+						artistUri:
+							prefixUri(tt.track.artists[0]?.externalIds?.spotify?.[0], "artist") ??
+							`listening-stats:artist:${tt.track.artists[0]?.name ?? ""}`,
+						albumName: tt.track.albums[0]?.name ?? "",
+						albumUri: prefixUri(tt.track.albums[0]?.externalIds?.spotify?.[0], "album") ?? "",
+						albumArt: tt.track.albums[0]?.image,
+						count: streams,
+						durationMs: tt.track.durationMs * streams,
+					};
+				});
 				onWave({ topTracks }, 2);
 				if (!isPlus) {
 					topAlbums = deriveAlbumsFromTracks(tracks);
@@ -627,7 +650,7 @@ export class StatsFmProvider implements StatsProvider {
 						prefixUri(ta.artist.externalIds?.spotify?.[0], "artist") ??
 						`listening-stats:artist:${ta.artist.name}`,
 					artistName: ta.artist.name,
-					count: ta.streams,
+					count: ta.streams ?? 0,
 					durationMs: ta.playedMs ?? 0,
 					genres: ta.artist.genres,
 					imageUrl: ta.artist.image ?? null,
@@ -650,7 +673,7 @@ export class StatsFmProvider implements StatsProvider {
 					albumName: ab.album.name,
 					artistName: ab.album.artists[0]?.name ?? "",
 					albumArt: ab.album.image,
-					count: ab.streams,
+					count: ab.streams ?? 0,
 					durationMs: 0,
 				}));
 				onWave({ topAlbums }, 2);

--- a/src/shared/stats/statsfm-provider.ts
+++ b/src/shared/stats/statsfm-provider.ts
@@ -90,7 +90,7 @@ function genresFromArtists(artists: SfmTopArtist[]): TopGenre[] {
 	const weighted = new Map<string, number>();
 	for (const ta of artists) {
 		for (const genre of ta.artist.genres) {
-			weighted.set(genre, (weighted.get(genre) ?? 0) + (+(ta.streams ?? 0)));
+			weighted.set(genre, (weighted.get(genre) ?? 0) + +(ta.streams ?? 0));
 		}
 	}
 	const hasWeight = [...weighted.values()].some((c) => c > 0);
@@ -112,10 +112,7 @@ function genresFromArtists(artists: SfmTopArtist[]): TopGenre[] {
 }
 
 /** Prefer stats.fm `/top/genres` when the API returns rows with non-zero counts (works even when artist.genres[] is empty). */
-function topGenresFromApiOrArtists(
-	apiRows: SfmTopGenre[] | null | undefined,
-	artists: SfmTopArtist[],
-): TopGenre[] {
+function topGenresFromApiOrArtists(apiRows: SfmTopGenre[] | null | undefined, artists: SfmTopArtist[]): TopGenre[] {
 	const rows = apiRows ?? [];
 	if (rows.length > 0) {
 		const mapped = [...rows]


### PR DESCRIPTION
## Description
Fix three bugs in the stats.fm provider:
1. "<1 min" and "null plays"— stats.fm free tier returns `null`/`undefined` for `streams` and `durationMs` on track/artist objects. Added `?? 0` fallback and `+(...)` numeric coercion to prevent `NaN` / `"undefined"` strings in the UI.
2. Top Genres all 0% — The `/top/genres` API returns rows with `streams: 0` for free accounts, and `ta.streams` on artist objects is also `null`/`0`, causing weighted genre counts to always be 0. Fix:
   - Skip API genre rows when total count is 0 (fall through to artist-based)
   - Fall back to **unweighted** genre counting (1 per artist per genre) when all weighted counts are 0
3. **Export broken for stats.fm** — `DataTab.tsx` hardcoded `LOCAL_PERIODS[4]` (id `"all-time"`) which doesn't match stats.fm period ids (`"sfm-all-time"`). Now resolves dynamically via `getSupportedPeriods().find(p => p.id.endsWith("all-time"))`.
## Type of Change
- [x] Bug fix
## Related Issue
Fixes #32, Fixes #33
## How to Test
1. `npm install && npm run build`
2. Deploy: `npm run deploy`
3. Open Listening Stats in Spotify sidebar
4. Switch to stats.fm provider
5. Verify tracks/artists show correct play counts (no "null" or "<1 min")
6. Check Top Genres show non-zero percentages
7. Test JSON/CSV export in Settings → Data
## Checklist
- [x] Tested locally with `npm run build` (no errors)
- [x] Tested in Spotify with Spicetify applied
- [x] Changes work with stats.fm provider
- [x] No sensitive data included
## Files Changed
- `src/shared/stats/statsfm-provider.ts` — null-safe streams, genre fallback logic, numeric coercion
- `src/app/components/settings/DataTab.tsx` — dynamic all-time period resolution