### PR TITLE
Increase heatmap cells, total-time font, genre bars proportional to total

### DIFF
--- a/src/app/components/CalendarHeatmap.tsx
+++ b/src/app/components/CalendarHeatmap.tsx
@@ -86,7 +86,7 @@ export function CalendarHeatmap({ dailyPlayCounts }: CalendarHeatmapProps) {
 		1,
 	);
 
-	const colWidth = "11px";
+	const colWidth = "16px";
 	const gridCols = `repeat(${numWeeks}, ${colWidth})`;
 
 	return (

--- a/src/app/components/OverviewSection.tsx
+++ b/src/app/components/OverviewSection.tsx
@@ -115,7 +115,7 @@ function OverviewHero({
 				<span
 					data-testid="hero-hours"
 					style={{
-						fontSize: 64,
+						fontSize: 80,
 						fontWeight: 800,
 						letterSpacing: "-0.04em",
 						lineHeight: 1,
@@ -124,13 +124,13 @@ function OverviewHero({
 				>
 					{h}
 				</span>
-				<span style={{ fontSize: 24, fontWeight: 600, color: "rgba(var(--spice-rgb-text), 0.6)" }}>
+				<span style={{ fontSize: 28, fontWeight: 600, color: "rgba(var(--spice-rgb-text), 0.6)" }}>
 					h
 				</span>
 				<span
 					data-testid="hero-minutes"
 					style={{
-						fontSize: 36,
+						fontSize: 48,
 						fontWeight: 700,
 						letterSpacing: "-0.03em",
 						fontVariantNumeric: "tabular-nums",
@@ -138,7 +138,7 @@ function OverviewHero({
 				>
 					{m.toString().padStart(2, "0")}
 				</span>
-				<span style={{ fontSize: 18, fontWeight: 600, color: "rgba(var(--spice-rgb-text), 0.6)" }}>
+				<span style={{ fontSize: 22, fontWeight: 600, color: "rgba(var(--spice-rgb-text), 0.6)" }}>
 					m
 				</span>
 				{showDelta && deltaPct != null && (

--- a/src/app/components/OverviewSection.tsx
+++ b/src/app/components/OverviewSection.tsx
@@ -122,9 +122,7 @@ function OverviewHero({
 				>
 					{h}
 				</span>
-				<span style={{ fontSize: 28, fontWeight: 600, color: "rgba(var(--spice-rgb-text), 0.6)" }}>
-					h
-				</span>
+				<span style={{ fontSize: 28, fontWeight: 600, color: "rgba(var(--spice-rgb-text), 0.6)" }}>h</span>
 				<span
 					data-testid="hero-minutes"
 					style={{
@@ -136,9 +134,7 @@ function OverviewHero({
 				>
 					{m.toString().padStart(2, "0")}
 				</span>
-				<span style={{ fontSize: 22, fontWeight: 600, color: "rgba(var(--spice-rgb-text), 0.6)" }}>
-					m
-				</span>
+				<span style={{ fontSize: 22, fontWeight: 600, color: "rgba(var(--spice-rgb-text), 0.6)" }}>m</span>
 				{showDelta && deltaPct != null && (
 					<span
 						data-testid="hero-delta"

--- a/src/app/components/TopGenres.tsx
+++ b/src/app/components/TopGenres.tsx
@@ -10,7 +10,6 @@ export function TopGenres({ topGenres, onGenreClick, activeGenre }: TopGenresPro
 	if (!topGenres || topGenres.length === 0) return null;
 
 	const genres = topGenres.slice(0, 6);
-	const maxCount = Math.max(1, genres[0]?.count ?? 0);
 	const totalCount = topGenres.reduce((s, g) => s + g.count, 0) || 1;
 
 	return (
@@ -21,7 +20,7 @@ export function TopGenres({ topGenres, onGenreClick, activeGenre }: TopGenresPro
 			</header>
 			<div className="top-genres-list">
 				{genres.map((genre, i) => {
-					const pct = (genre.count / maxCount) * 100;
+					const pct = totalCount > 0 ? (genre.count / totalCount) * 100 : 0;
 					return (
 						<div key={genre.genre} className="top-genres-row">
 							<button

--- a/src/app/styles.css
+++ b/src/app/styles.css
@@ -1614,6 +1614,7 @@ button.announcement-banner-link-btn:hover {
 	position: relative;
 	padding-top: 18px;
 	overflow-x: auto;
+	overflow-y: visible;
 }
 
 .heatmap-scroll-inner {
@@ -1625,7 +1626,7 @@ button.announcement-banner-link-btn:hover {
 	gap: 3px;
 	font-size: 10px;
 	color: rgba(var(--spice-rgb-text), 0.5);
-	height: 14px;
+	height: 16px;
 	margin-bottom: 4px;
 }
 
@@ -1636,14 +1637,14 @@ button.announcement-banner-link-btn:hover {
 
 .heatmap-week {
 	display: grid;
-	grid-template-rows: repeat(7, 11px);
+	grid-template-rows: repeat(7, 16px);
 	gap: 3px;
 }
 
 .heatmap-cell {
-	width: 11px;
-	height: 11px;
-	border-radius: 2px;
+	width: 16px;
+	height: 16px;
+	border-radius: 3px;
 }
 
 .heatmap-legend {
@@ -1658,9 +1659,9 @@ button.announcement-banner-link-btn:hover {
 
 .heatmap-legend-swatch {
 	display: inline-block;
-	width: 11px;
-	height: 11px;
-	border-radius: 2px;
+	width: 16px;
+	height: 16px;
+	border-radius: 3px;
 }
 
 /* Streak callout */

--- a/src/test/top-genres.test.ts
+++ b/src/test/top-genres.test.ts
@@ -88,24 +88,24 @@ describe("TopGenres component", () => {
 		expect(bars[2]?.classList.contains("peak")).toBe(false);
 	});
 
-	it("bar width of rank-1 genre is '100%'", async () => {
+	it("bar width proportional to totalCount for rank-1 genre", async () => {
 		const { TopGenres } = await import("../app/components/TopGenres");
 		Spicetify.ReactDOM.render(
 			Spicetify.React.createElement(TopGenres, { topGenres: mockGenres }),
 			container,
 		);
 		const bars = container.querySelectorAll<HTMLElement>(".top-genres-bar");
-		expect(bars[0]?.style.width).toBe("100%");
+		expect(bars[0]?.style.width).toBe("57.14285714285714%");
 	});
 
-	it("bar width proportional  -  genre with half the count of max gets '50%' width", async () => {
+	it("bar width proportional  -  genre with half the top count gets '28.57%' width", async () => {
 		const { TopGenres } = await import("../app/components/TopGenres");
 		Spicetify.ReactDOM.render(
 			Spicetify.React.createElement(TopGenres, { topGenres: mockGenres }),
 			container,
 		);
 		const bars = container.querySelectorAll<HTMLElement>(".top-genres-bar");
-		expect(bars[1]?.style.width).toBe("50%");
+		expect(bars[1]?.style.width).toBe("28.57142857142857%");
 	});
 
 	it("genre name displayed in .top-genres-name button, percentage in .top-genres-pct", async () => {


### PR DESCRIPTION
## Description
Three UI tweaks:
1. Heatmap cells — Increased from 11px → 16px with matching CSS grid/legend adjustments for better readability. Container uses `overflow-x: auto` so it scrolls if needed.
2. Total time display — Larger hero numbers in OverviewSection: hours 64→80px, minutes 36→48px, unit labels proportionally bigger.
3. **Genre bars proportional to total** — Previously bars filled 100% for the top genre regardless of its actual share. Now bar width reflects the genre's percentage of total plays (`genre.count / totalCount`), so e.g. an 18% genre fills 18% of the bar track.
## Type of Change
- [x] Enhancement / improvement
## How to Test
1. `npm install && npm run build`
2. Deploy to Spicetify
3. Open Listening Stats
4. Check Top Genres — bars should match the percentage shown
5. Check Total Time hero — numbers should be noticeably larger
6. Switch to "By month" tab in Activity — heatmap cells should be bigger
## Checklist
- [x] Tested locally with `npm run build` (no errors)
- [x] Tested in Spotify with Spicetify applied
- [x] No sensitive data included
## Files Changed
- `src/app/components/OverviewSection.tsx` — larger total-time font sizes
- `src/app/components/CalendarHeatmap.tsx` — cell width 14px→16px
- `src/app/components/TopGenres.tsx` — bar width proportional to totalCount
- `src/app/styles.css` — heatmap cell/legend sizes, grid rows
- `src/test/top-genres.test.ts` — updated bar width expectations