### PR TITLE
feat: UX fixes in ShareModal, dashboard drag-to-reorder, Easter Egg added, period label fixes

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -25,6 +25,7 @@ import { getActivityMode, getSectionsForProvider } from "./capabilities";
 import { ActivitySection } from "./components/ActivitySection";
 import { AnnouncementBanner } from "./components/AnnouncementBanner";
 import { AppFooter } from "./components/AppFooter";
+import { ConfettiOverlay } from "./components/ConfettiOverlay";
 import { ConsistencySection } from "./components/ConsistencySection";
 import EmptyState from "./components/EmptyState";
 import { clearActiveGenre, FilterPill, setActiveGenre } from "./components/FilterPill";
@@ -34,13 +35,16 @@ import { InlineErrorCard } from "./components/InlineErrorCard";
 import OverviewSection from "./components/OverviewSection";
 import { RecentlyPlayed } from "./components/RecentlyPlayed";
 import { SetupWizard } from "./components/SetupWizard";
-import { ShareModal } from "./components/ShareModal";
+import { ShareModal, type ShareVariant } from "./components/ShareModal";
 import type { SettingsTab } from "./components/settings/SettingsModal";
 import { SettingsModal } from "./components/settings/SettingsModal";
 import { TopGenres } from "./components/TopGenres";
 import { TopLists } from "./components/TopLists";
 import { UpdateModal } from "./components/UpdateModal";
 import { WorldChartsPage } from "./components/WorldChartsPage";
+import { useKonamiCode } from "./hooks/useKonamiCode";
+import { useSettingsSortable } from "./hooks/useSettingsSortable";
+import { ChevronGripIcon } from "./icons";
 import { getPreferences, setPreference } from "./preferences";
 import { getTourSteps, shouldAutoStartTour } from "./tour";
 
@@ -97,6 +101,7 @@ function App() {
 	const [tourActive, setTourActive] = useState(() => shouldAutoStartTour(__VERSION__));
 	const [activePage, setActivePage] = useState<string>(() => getPreferences().activePage);
 	const [showShare, setShowShare] = useState(false);
+	const [shareVariant, setShareVariant] = useState<string>("top5");
 	const [remoteAnnouncement, setRemoteAnnouncement] = useState<ParsedRemoteAnnouncement | null>(null);
 	const [updateCheck, setUpdateCheck] = useState<UpdateCheckResult | null>(null);
 	const [showUpdateModal, setShowUpdateModal] = useState(false);
@@ -292,6 +297,18 @@ function App() {
 	void prefsVersion;
 	const isHidden = (id: string) => prefs.hiddenSections.includes(id);
 
+	const sectionSortable = useSettingsSortable({
+		order: prefs.sectionOrder.filter((id) => availableSectionIds.has(id) && !isHidden(id)),
+		orientation: "vertical",
+		onReorder: (next) => {
+			setPreference("sectionOrder", next);
+			window.dispatchEvent(new CustomEvent(EVENTS.PREFS_CHANGED));
+		},
+	});
+
+	const [showConfetti, setShowConfetti] = useState(false);
+	useKonamiCode(() => setShowConfetti(true));
+
 	const handlePrefsChanged = useCallback(() => {
 		setPrefsVersion((v) => v + 1);
 	}, []);
@@ -347,6 +364,11 @@ function App() {
 	const isSlotLoading = (slot: keyof SectionSlots) =>
 		sectionSlots[slot] === "loading" || sectionSlots[slot] === "pending";
 
+	const shareSection = useCallback((variant: string) => {
+		setShareVariant(variant);
+		setShowShare(true);
+	}, []);
+
 	const renderSectionById = (id: string): React.ReactNode => {
 		switch (id) {
 			case "overview":
@@ -360,12 +382,19 @@ function App() {
 						/>
 					);
 				if (!stats) return null;
-				return <OverviewSection stats={stats} activePeriod={activePeriod} />;
+				return <OverviewSection stats={stats} activePeriod={activePeriod} onShare={() => shareSection("time")} />;
 			case "top-genres":
 				if (isSlotLoading("lists") || !stats) return null;
 				if (!capabilities?.hasGenreData) return null;
 				if (stats.topGenres.length === 0) return null;
-				return <TopGenres topGenres={stats.topGenres} onGenreClick={setActiveGenre} activeGenre={prefs.activeGenre} />;
+				return (
+					<TopGenres
+						topGenres={stats.topGenres}
+						onGenreClick={setActiveGenre}
+						activeGenre={prefs.activeGenre}
+						onShare={() => shareSection("genre")}
+					/>
+				);
 			case "top-lists": {
 				const listsLoading = isSlotLoading("lists");
 				if (sectionErrors.lists)
@@ -385,6 +414,11 @@ function App() {
 						hiddenSections={prefs.hiddenSections}
 						onGenreClick={setActiveGenre}
 						activeGenre={prefs.activeGenre}
+						onShare={{
+							tracks: () => shareSection("top5"),
+							artists: () => shareSection("wrapped"),
+							albums: () => shareSection("throwback"),
+						}}
 					/>
 				);
 			}
@@ -423,6 +457,7 @@ function App() {
 						dailyPlayCounts={stats.dailyPlayCounts}
 						streak={stats.streak}
 						showStreak={showStreak}
+						onShare={() => shareSection("streak")}
 					/>
 				);
 			}
@@ -447,13 +482,14 @@ function App() {
 						streak={stats.streak}
 						activePeriod={activePeriod}
 						activeProviderId={activeProviderId}
+						onShare={() => shareSection("streak")}
 					/>
 				);
 			}
 			case "recently-played":
 				if (isSlotLoading("overview")) return <RecentlyPlayed loading />;
 				if (!stats) return null;
-				return <RecentlyPlayed recentPlays={stats.recentPlays} />;
+				return <RecentlyPlayed recentPlays={stats.recentPlays} onShare={() => shareSection("throwback")} />;
 			default:
 				return null;
 		}
@@ -482,9 +518,10 @@ function App() {
 			.filter(([, status]) => status === "loading" || status === "pending")
 			.map(([key]) => key);
 		const hasLoading = loadingSections.length > 0;
+		const { isDragging, dropSlotIndex } = sectionSortable.dragState;
 
 		return (
-			<div className="stats-page-content">
+			<div className="stats-page-content" data-drag-active={isDragging || undefined}>
 				{hasLoading && (
 					<div className="loading-status-banner" role="status" aria-live="polite">
 						<span className="loading-status-dot" />
@@ -493,14 +530,30 @@ function App() {
 						</span>
 					</div>
 				)}
-				{visibleSections.map((id) => {
+				{visibleSections.map((id, idx) => {
 					const content = renderSectionById(id);
-					return content ? (
-						<div key={id} data-section-id={id}>
-							{content}
-						</div>
-					) : null;
+					const dragStyle = sectionSortable.getItemStyle(id);
+					return (
+						<Spicetify.React.Fragment key={id}>
+							<div className="dashboard-drop-line" data-active={dropSlotIndex === idx || undefined} />
+							{content ? (
+								<div data-section-id={id} ref={(el) => sectionSortable.registerItem(id, el)} style={dragStyle}>
+									<div className="dashboard-section-row">
+										<button
+											type="button"
+											className="dashboard-drag-handle"
+											aria-label="Drag section"
+											onPointerDown={(e) => sectionSortable.onItemPointerDown(id)(e.nativeEvent)}
+											dangerouslySetInnerHTML={{ __html: ChevronGripIcon }}
+										/>
+										<div className="dashboard-section-content">{content}</div>
+									</div>
+								</div>
+							) : null}
+						</Spicetify.React.Fragment>
+					);
 				})}
+				<div className="dashboard-drop-line" data-active={dropSlotIndex === visibleSections.length || undefined} />
 			</div>
 		);
 	};
@@ -602,7 +655,12 @@ function App() {
 				onComplete={() => setTourActive(false)}
 			/>
 			{showShare && stats && (
-				<ShareModal stats={stats} activePeriod={activePeriod} onClose={() => setShowShare(false)} />
+				<ShareModal
+					stats={stats}
+					activePeriod={activePeriod}
+					initialVariant={shareVariant as ShareVariant}
+					onClose={() => setShowShare(false)}
+				/>
 			)}
 			<UpdateModal
 				open={showUpdateModal}
@@ -612,6 +670,7 @@ function App() {
 				receiveBetaUpdates={prefs.receiveBetaUpdates}
 				onReceiveBetaUpdatesChange={handleReceiveBetaUpdatesChange}
 			/>
+			{showConfetti && <ConfettiOverlay onComplete={() => setShowConfetti(false)} />}
 		</div>
 	);
 }

--- a/src/app/components/ActivitySection.tsx
+++ b/src/app/components/ActivitySection.tsx
@@ -1,4 +1,5 @@
 import { formatHour } from "../format";
+import { ShareIcon } from "../icons";
 import type { ActivityTabId } from "../preferences";
 import { getPreferences, setPreference } from "../preferences";
 import { CalendarHeatmap } from "./CalendarHeatmap";
@@ -26,6 +27,7 @@ interface ActivitySectionProps {
 	dailyPlayCounts?: Array<{ date: string; count: number }>;
 	streak?: number;
 	showStreak: boolean;
+	onShare?: () => void;
 }
 
 export function ActivitySection({
@@ -37,6 +39,7 @@ export function ActivitySection({
 	dailyPlayCounts,
 	streak,
 	showStreak,
+	onShare,
 }: ActivitySectionProps) {
 	const prefs = getPreferences();
 	const [activeTab, setActiveTab] = useState<ActivityTabId>(() => prefs.activityTab);
@@ -75,6 +78,19 @@ export function ActivitySection({
 				<header className="section-heading" style={{ marginBottom: 0 }}>
 					<span className="section-kicker">Patterns</span>
 					<h2 className="section-title">Activity</h2>
+					{onShare && (
+						<button
+							type="button"
+							className="btn-icon share-section-btn"
+							style={{ marginLeft: "auto" }}
+							onClick={(e) => {
+								e.stopPropagation();
+								onShare();
+							}}
+							aria-label="Share activity"
+							dangerouslySetInnerHTML={{ __html: ShareIcon }}
+						/>
+					)}
 				</header>
 				{peakLabel && (
 					<div className="activity-chart-peak">

--- a/src/app/components/ConfettiOverlay.tsx
+++ b/src/app/components/ConfettiOverlay.tsx
@@ -1,0 +1,68 @@
+const { useEffect, useMemo } = Spicetify.React;
+
+interface ConfettiOverlayProps {
+	onComplete: () => void;
+}
+
+interface Particle {
+	id: number;
+	x: number;
+	delay: number;
+	duration: number;
+	size: number;
+	color: string;
+	rotation: number;
+}
+
+const COLORS = [
+	"var(--spice-button-active)",
+	"var(--spice-text)",
+	"#ff6b6b",
+	"#ffd93d",
+	"#6bcb77",
+	"#4d96ff",
+	"#ff6bff",
+];
+
+export function ConfettiOverlay({ onComplete }: ConfettiOverlayProps) {
+	const particles: Particle[] = useMemo(() => {
+		const out: Particle[] = [];
+		for (let i = 0; i < 100; i++) {
+			out.push({
+				id: i,
+				x: Math.random() * 100,
+				delay: Math.random() * 0.5,
+				duration: 2 + Math.random() * 2,
+				size: 6 + Math.random() * 8,
+				color: COLORS[Math.floor(Math.random() * COLORS.length)],
+				rotation: Math.random() * 360,
+			});
+		}
+		return out;
+	}, []);
+
+	useEffect(() => {
+		const timer = setTimeout(onComplete, 4500);
+		return () => clearTimeout(timer);
+	}, [onComplete]);
+
+	return (
+		<div className="confetti-overlay">
+			{particles.map((p) => (
+				<div
+					key={p.id}
+					className="confetti-particle"
+					style={{
+						left: `${p.x}%`,
+						width: p.size,
+						height: p.size * 0.6,
+						background: p.color,
+						animationDelay: `${p.delay}s`,
+						animationDuration: `${p.duration}s`,
+						transform: `rotate(${p.rotation}deg)`,
+					}}
+				/>
+			))}
+		</div>
+	);
+}

--- a/src/app/components/ConsistencySection.tsx
+++ b/src/app/components/ConsistencySection.tsx
@@ -1,4 +1,5 @@
 import type { Period } from "../../shared/types/stats";
+import { ShareIcon } from "../icons";
 import { SkeletonBlock, SkeletonTextLine } from "./SkeletonPrimitives";
 
 interface DailyPoint {
@@ -15,6 +16,7 @@ interface ConsistencySectionProps {
 	streak?: number;
 	activePeriod: Period;
 	activeProviderId?: string;
+	onShare?: () => void;
 }
 
 interface MetricCardProps {
@@ -63,6 +65,7 @@ export function ConsistencySection({
 	streak,
 	activePeriod,
 	activeProviderId = "statsfm",
+	onShare,
 }: ConsistencySectionProps) {
 	if (loading) {
 		return (
@@ -110,6 +113,19 @@ export function ConsistencySection({
 			<header className="section-heading">
 				<span className="section-kicker">Patterns</span>
 				<h2 className="section-title">Consistency</h2>
+				{onShare && (
+					<button
+						type="button"
+						className="btn-icon share-section-btn"
+						style={{ marginLeft: "auto" }}
+						onClick={(e) => {
+							e.stopPropagation();
+							onShare();
+						}}
+						aria-label="Share consistency"
+						dangerouslySetInnerHTML={{ __html: ShareIcon }}
+					/>
+				)}
 			</header>
 			<div className="consistency-grid">
 				<MetricCard

--- a/src/app/components/OverviewSection.tsx
+++ b/src/app/components/OverviewSection.tsx
@@ -1,7 +1,7 @@
 import { providerRegistry } from "../../shared/stats/provider";
 import type { Period, StatsResult } from "../../shared/types/stats";
 import { formatEstimatedPayout, formatHour, formatNumber } from "../format";
-import { ClockIcon } from "../icons";
+import { ClockIcon, ShareIcon } from "../icons";
 import type { OverviewProviderKey } from "../preferences";
 import { getPreferences, OVERVIEW_CARD_LABELS } from "../preferences";
 import { SkeletonBlock } from "./SkeletonPrimitives";
@@ -12,6 +12,7 @@ interface OverviewSectionProps {
 	stats?: StatsResult | null;
 	activePeriod: Period;
 	loading?: boolean;
+	onShare?: () => void;
 }
 
 interface StatCardSpec {
@@ -28,6 +29,7 @@ function OverviewHero({
 	uniqueArtistCount,
 	periodLabel,
 	periodKey,
+	onShare,
 }: {
 	totalDuration: number;
 	priorPeriodTotalDuration: number | undefined;
@@ -35,6 +37,7 @@ function OverviewHero({
 	uniqueArtistCount: number;
 	periodLabel: string;
 	periodKey: string;
+	onShare?: () => void;
 }) {
 	const reduce = useMemo(
 		() => typeof window.matchMedia === "function" && window.matchMedia("(prefers-reduced-motion: reduce)").matches,
@@ -100,6 +103,19 @@ function OverviewHero({
 			>
 				<span dangerouslySetInnerHTML={{ __html: ClockIcon }} />
 				<span>Total time - {periodLabel}</span>
+				{onShare && (
+					<button
+						type="button"
+						className="btn-icon share-section-btn"
+						style={{ marginLeft: "auto" }}
+						onClick={(e) => {
+							e.stopPropagation();
+							onShare();
+						}}
+						aria-label="Share total time"
+						dangerouslySetInnerHTML={{ __html: ShareIcon }}
+					/>
+				)}
 			</div>
 
 			<div
@@ -189,7 +205,7 @@ function OverviewSectionSkeleton() {
 	);
 }
 
-export default function OverviewSection({ stats, activePeriod, loading = false }: OverviewSectionProps) {
+export default function OverviewSection({ stats, activePeriod, loading = false, onShare }: OverviewSectionProps) {
 	if (loading || !stats) return <OverviewSectionSkeleton />;
 	const prefs = getPreferences();
 	const activeId = providerRegistry.getActive()?.getProviderInfo().id ?? "local";
@@ -277,6 +293,7 @@ export default function OverviewSection({ stats, activePeriod, loading = false }
 				uniqueArtistCount={stats.uniqueArtistCount}
 				periodLabel={activePeriod.label}
 				periodKey={activePeriod.id}
+				onShare={onShare}
 			/>
 			{top4.length > 0 && (
 				<div className="overview-right-block" style={{ gridTemplateColumns: `repeat(${topColumns}, minmax(0, 1fr))` }}>

--- a/src/app/components/RecentlyPlayed.tsx
+++ b/src/app/components/RecentlyPlayed.tsx
@@ -1,20 +1,35 @@
 import type { RecentPlay } from "../../shared/types/stats";
 import { normalizeSpotifyImageUrl } from "../../shared/util/spotify-image-url";
 import { formatRelativeTime } from "../format";
+import { ShareIcon } from "../icons";
 import { navigateToUri } from "../utils";
 import { SkeletonBlock } from "./SkeletonPrimitives";
 
 interface RecentlyPlayedProps {
 	recentPlays?: RecentPlay[];
 	loading?: boolean;
+	onShare?: () => void;
 }
 
-export function RecentlyPlayed({ recentPlays = [], loading = false }: RecentlyPlayedProps) {
+export function RecentlyPlayed({ recentPlays = [], loading = false, onShare }: RecentlyPlayedProps) {
 	return (
 		<div className="section-card">
 			<header className="section-heading">
 				<span className="section-kicker">Last 24h</span>
 				<h2 className="section-title">Recently Played</h2>
+				{onShare && (
+					<button
+						type="button"
+						className="btn-icon share-section-btn"
+						style={{ marginLeft: "auto" }}
+						onClick={(e) => {
+							e.stopPropagation();
+							onShare();
+						}}
+						aria-label="Share recently played"
+						dangerouslySetInnerHTML={{ __html: ShareIcon }}
+					/>
+				)}
 			</header>
 			<div className="recently-played">
 				{loading

--- a/src/app/components/ShareModal.tsx
+++ b/src/app/components/ShareModal.tsx
@@ -8,17 +8,20 @@ import { CloseIcon } from "../icons";
 
 const { useState, useCallback, useEffect, useMemo } = Spicetify.React;
 
-type ShareVariant = "top5" | "time" | "genre" | "streak" | "throwback" | "wrapped";
+export type ShareVariant = "top5" | "time" | "genre" | "streak" | "throwback" | "wrapped";
 type ShareSize = "square" | "story";
 
 interface ShareModalProps {
 	stats: StatsResult;
 	activePeriod: Period;
 	onClose: () => void;
+	initialVariant?: ShareVariant;
 }
 
 interface ShareRenderOptions {
 	followTheme?: boolean;
+	showUsername?: boolean;
+	showPeriodLabel?: boolean;
 	activeProviderId?: string;
 	periodDayCount?: number;
 }
@@ -58,22 +61,24 @@ function getShareCaptionHandle(): string {
 	return "";
 }
 
-export function ShareModal({ stats, activePeriod, onClose }: ShareModalProps) {
-	const [variant, setVariant] = useState<ShareVariant>("top5");
+export function ShareModal({ stats, activePeriod, onClose, initialVariant }: ShareModalProps) {
+	const [variant, setVariant] = useState<ShareVariant>(initialVariant ?? "top5");
 	const [size, setSize] = useState<ShareSize>("square");
 	const [followTheme, setFollowTheme] = useState(false);
+	const [showUsername, setShowUsername] = useState(true);
+	const [showPeriodLabel, setShowPeriodLabel] = useState(true);
 	const [busy, setBusy] = useState(false);
 	const [previewUrl, setPreviewUrl] = useState<string>("");
 	const [previewLoading, setPreviewLoading] = useState(false);
 	const [previewError, setPreviewError] = useState<string | null>(null);
 
+	const Toggle = Spicetify.ReactComponent.Toggle;
 	const username = getShareCaptionHandle();
 	const periodLabel = activePeriod.label;
 	const periodBoundaries = activePeriod.getBoundaries();
 	const periodDayCount = Math.max(1, Math.round((periodBoundaries.end - periodBoundaries.start) / 86_400_000));
 	const activeProviderId = providerRegistry.getActiveId() ?? "local";
 	const caps = providerRegistry.getActive()?.getProviderInfo().capabilities;
-
 	const availableVariants = useMemo(() => {
 		return VARIANTS.filter((v) => {
 			if (v.id === "genre") {
@@ -100,6 +105,8 @@ export function ShareModal({ stats, activePeriod, onClose }: ShareModalProps) {
 			try {
 				const blob = await renderShareCardBlob(stats, variant, size, periodLabel, username, {
 					followTheme,
+					showUsername,
+					showPeriodLabel,
 					activeProviderId,
 					periodDayCount,
 				});
@@ -117,7 +124,18 @@ export function ShareModal({ stats, activePeriod, onClose }: ShareModalProps) {
 			canceled = true;
 			if (currentUrl) URL.revokeObjectURL(currentUrl);
 		};
-	}, [stats, variant, size, periodLabel, username, followTheme, activeProviderId, periodDayCount]);
+	}, [
+		stats,
+		variant,
+		size,
+		periodLabel,
+		username,
+		followTheme,
+		showUsername,
+		showPeriodLabel,
+		activeProviderId,
+		periodDayCount,
+	]);
 
 	const handleVariantChange = (v: ShareVariant) => setVariant(v);
 
@@ -136,6 +154,8 @@ export function ShareModal({ stats, activePeriod, onClose }: ShareModalProps) {
 		try {
 			await exportShareCardPng(stats, variant, size, periodLabel, username, {
 				followTheme,
+				showUsername,
+				showPeriodLabel,
 				activeProviderId,
 				periodDayCount,
 			});
@@ -145,7 +165,19 @@ export function ShareModal({ stats, activePeriod, onClose }: ShareModalProps) {
 		} finally {
 			setBusy(false);
 		}
-	}, [stats, variant, size, periodLabel, username, followTheme, activeProviderId, periodDayCount, busy]);
+	}, [
+		stats,
+		variant,
+		size,
+		periodLabel,
+		username,
+		followTheme,
+		showUsername,
+		showPeriodLabel,
+		activeProviderId,
+		periodDayCount,
+		busy,
+	]);
 
 	const handleCopy = useCallback(async () => {
 		if (busy) return;
@@ -153,6 +185,8 @@ export function ShareModal({ stats, activePeriod, onClose }: ShareModalProps) {
 		try {
 			await copyShareCardToClipboard(stats, variant, size, periodLabel, username, {
 				followTheme,
+				showUsername,
+				showPeriodLabel,
 				activeProviderId,
 				periodDayCount,
 			});
@@ -162,7 +196,19 @@ export function ShareModal({ stats, activePeriod, onClose }: ShareModalProps) {
 		} finally {
 			setBusy(false);
 		}
-	}, [stats, variant, size, periodLabel, username, followTheme, activeProviderId, periodDayCount, busy]);
+	}, [
+		stats,
+		variant,
+		size,
+		periodLabel,
+		username,
+		followTheme,
+		showUsername,
+		showPeriodLabel,
+		activeProviderId,
+		periodDayCount,
+		busy,
+	]);
 
 	return Spicetify.ReactDOM.createPortal(
 		<div className="share-overlay" onClick={handleOverlayClick}>
@@ -211,15 +257,9 @@ export function ShareModal({ stats, activePeriod, onClose }: ShareModalProps) {
 				</div>
 
 				<div className="share-control-row">
-					<label className="share-toggle-row">
-						<input type="checkbox" checked={followTheme} onChange={(e) => setFollowTheme(e.currentTarget.checked)} />
-						<span>Follow theme</span>
-					</label>
-					<span className="share-control-help">
-						{followTheme ? "Card uses current Spotify theme colors." : "Card uses default locked green share palette."}
-					</span>
+					<span style={{ fontSize: 12, color: "var(--spice-text)" }}>Follow theme</span>
+					<Toggle value={followTheme} onSelected={setFollowTheme} />
 				</div>
-
 				<div className="share-preview-container">
 					{previewLoading && <div className="share-preview-status">Rendering preview…</div>}
 					{previewError && <div className="share-preview-status">{previewError}</div>}
@@ -252,6 +292,15 @@ export function ShareModal({ stats, activePeriod, onClose }: ShareModalProps) {
 					>
 						{busy ? "Working…" : "Save PNG"}
 					</button>
+				</div>
+
+				<div className="share-control-row" style={{ marginTop: 8 }}>
+					<span style={{ fontSize: 12, color: "var(--spice-text)" }}>Show @username</span>
+					<Toggle value={showUsername} onSelected={setShowUsername} />
+				</div>
+				<div className="share-control-row">
+					<span style={{ fontSize: 12, color: "var(--spice-text)" }}>Show period label</span>
+					<Toggle value={showPeriodLabel} onSelected={setShowPeriodLabel} />
 				</div>
 			</div>
 		</div>,
@@ -414,7 +463,7 @@ function ShareWrapped({ stats, size, periodLabel }: { stats: StatsResult; size: 
 	const tracks = stats.topTracks.slice(0, isStory ? 4 : 3);
 	const artists = stats.topArtists.slice(0, isStory ? 4 : 3);
 	const genres = stats.topGenres.slice(0, isStory ? 3 : 2);
-	const genreMaxCount = genres[0]?.count ?? 1;
+	const genreMaxCount = genres[0]?.count || 1;
 	const genreTotal = genres.reduce((s, x) => s + x.count, 0);
 	const head = periodLabel.trim().length > 0 ? `${periodLabel} · Wrapped` : "Wrapped";
 
@@ -443,7 +492,9 @@ function ShareWrapped({ stats, size, periodLabel }: { stats: StatsResult; size: 
 					lineHeight: 1.35,
 				}}
 			>
-				{formatNumber(stats.totalPlays)} plays · {stats.uniqueArtistCount} artists · peak {peakLabel}
+				{stats.totalPlays > 0
+					? `${formatNumber(stats.totalPlays)} plays · ${stats.uniqueArtistCount} artists · peak ${peakLabel}`
+					: ""}
 				{streak > 0 ? ` · ${streak}-day streak` : ""}
 			</div>
 
@@ -554,7 +605,7 @@ function ShareWrapped({ stats, size, periodLabel }: { stats: StatsResult; size: 
 										{a.artistName}
 									</div>
 									<div style={{ fontSize: isStory ? 9 : 8, color: "rgba(255,255,255,.55)" }}>
-										{a.count === 1 ? "1 play" : `${a.count} plays`}
+										{a.count > 0 ? (a.count === 1 ? "1 play" : `${a.count} plays`) : ""}
 									</div>
 								</div>
 							</li>
@@ -717,9 +768,11 @@ function ShareTime({ stats, periodLabel }: { stats: StatsResult; periodLabel: st
 function ShareGenre({ stats }: { stats: StatsResult }) {
 	const top = stats.topGenres.slice(0, 4);
 	if (top.length === 0) return null;
-	const maxCount = top[0].count;
+	const maxCount = top[0].count || 1;
 	const totalCount = top.reduce((s, g) => s + g.count, 0);
 	const topPct = totalCount > 0 ? Math.round((maxCount / totalCount) * 100) : 0;
+
+	if (totalCount === 0) return null;
 
 	return (
 		<div>
@@ -779,6 +832,7 @@ function ShareGenre({ stats }: { stats: StatsResult }) {
 
 function ShareStreak({ stats }: { stats: StatsResult }) {
 	const streak = stats.streak ?? 0;
+	if (streak === 0) return null;
 	const data = (stats.dailyPlayCounts ?? []).slice(-56);
 	const max = Math.max(1, ...data.map((d) => d.count));
 
@@ -828,7 +882,7 @@ function ShareStreak({ stats }: { stats: StatsResult }) {
 
 function ShareThrowback({ stats }: { stats: StatsResult }) {
 	const track = stats.topTracks[0];
-	if (!track) return null;
+	if (!track || track.count === 0) return null;
 
 	return (
 		<div data-testid="share-throwback-body">
@@ -1197,14 +1251,15 @@ async function drawTop5Content(
 	const cntPx = isStory ? (storyTight ? 28 : 32) : tightSq ? 22 : 28;
 	const playsLblPx = storyTight ? 16 : tightSq ? 15 : 18;
 
+	const allZeroPlays = tracks.every((t) => t.count === 0);
 	ctx.font = `700 ${cntPx}px ${CV_FONT}`;
 	let playNumMax = 0;
-	for (const t of tracks) playNumMax = Math.max(playNumMax, ctx.measureText(`${t.count}`).width);
+	for (const t of tracks) if (t.count > 0) playNumMax = Math.max(playNumMax, ctx.measureText(`${t.count}`).width);
 
 	ctx.font = `600 ${playsLblPx}px ${CV_FONT}`;
 	const defaultLetterSpacing = ctx.letterSpacing;
 	ctx.letterSpacing = "0.06em";
-	const playsLblW = ctx.measureText("PLAYS").width;
+	const playsLblW = allZeroPlays ? 0 : ctx.measureText("PLAYS").width;
 	ctx.letterSpacing = defaultLetterSpacing;
 
 	const playsReserve = Math.ceil(playNumMax + 14 + playsLblW + CV_PAD / 2);
@@ -1242,11 +1297,11 @@ async function drawTop5Content(
 		ctx.fillStyle = palette.text;
 		ctx.font = `700 ${cntPx}px ${CV_FONT}`;
 		ctx.textAlign = "right";
-		ctx.fillText(`${t.count}`, playsEdge, titleBase(ry));
+		ctx.fillText(t.count > 0 ? `${t.count}` : "", playsEdge, titleBase(ry));
 		ctx.fillStyle = palette.dimText;
 		ctx.font = `600 ${playsLblPx}px ${CV_FONT}`;
 		ctx.letterSpacing = "0.06em";
-		ctx.fillText("PLAYS", playsEdge, artistBase(ry));
+		if (t.count > 0) ctx.fillText("PLAYS", playsEdge, artistBase(ry));
 		ctx.letterSpacing = defaultLetterSpacing;
 		ctx.textAlign = "left";
 	}
@@ -1364,7 +1419,7 @@ async function drawTimeContent(
 	ctx.fillStyle = mutedBody;
 	ctx.font = `${26}px ${CV_FONT}`;
 	ctx.fillText(
-		cvTruncate(ctx, `across ${formatNumber(stats.totalPlays)} plays`, colW - 2 * inset),
+		stats.totalPlays > 0 ? cvTruncate(ctx, `across ${formatNumber(stats.totalPlays)} plays`, colW - 2 * inset) : "",
 		rightX,
 		chunkY + 162,
 	);
@@ -1394,7 +1449,7 @@ async function drawTimeContent(
 		if (!(await cvDrawArt(ctx, a.imageUrl ?? undefined, avatarX, ry, avatar, avatar / 2)))
 			cvPlaceholder(ctx, avatarX, ry, avatar, avatar / 2);
 		const nameX = avatarX + avatar + 22;
-		const playsLbl = `${formatNumber(a.count)} ${a.count === 1 ? "play" : "plays"}`;
+		const playsLbl = a.count > 0 ? `${formatNumber(a.count)} ${a.count === 1 ? "play" : "plays"}` : "";
 		ctx.font = `${28}px ${CV_FONT}`;
 		ctx.textAlign = "right";
 		ctx.fillStyle = palette.dimText;
@@ -1426,10 +1481,11 @@ async function drawGenreContent(
 	const top = stats.topGenres.slice(0, limit);
 	if (top.length === 0) return;
 
-	const maxCount = top[0].count;
+	const maxCount = top[0].count || 1;
 	const totalCount = top.reduce((s, g) => s + g.count, 0);
 	const topPct = totalCount > 0 ? Math.round((maxCount / totalCount) * 100) : 0;
 
+	if (totalCount === 0) return;
 	y = cvKicker(ctx, `I was ${topPct}% ${top[0].genre}`, x, y, palette);
 	const isStory = size === "story";
 	y += isStory ? 54 : 40;
@@ -1520,6 +1576,7 @@ async function drawStreakContent(
 	w: number,
 ) {
 	const streak = stats.streak ?? 0;
+	if (streak === 0) return;
 	const isStory = size === "story";
 	y = cvKicker(ctx, `${streak}-day streak`, x, y, palette, false, isStory ? 40 : 36);
 	y += isStory ? 54 : 32;
@@ -1633,8 +1690,8 @@ async function drawThrowbackContent(
 	y += isStory ? 110 : 70;
 	ctx.fillStyle = palette.mutedText;
 	ctx.font = `${isStory ? 44 : 32}px ${CV_FONT}`;
-	const playPhrase = track.count === 1 ? "1 play" : `${track.count} plays`;
-	ctx.fillText(cvTruncate(ctx, `${track.artistName} · ${playPhrase}`, w), x, y);
+	const playPhrase = track.count > 0 ? (track.count === 1 ? "1 play" : `${track.count} plays`) : "";
+	ctx.fillText(cvTruncate(ctx, playPhrase ? `${track.artistName} · ${playPhrase}` : track.artistName, w), x, y);
 
 	if (!isStory || stats.totalPlays <= 0) return;
 
@@ -1740,11 +1797,11 @@ async function drawWrappedCompactTrackRows(
 		ctx.fillStyle = palette.text;
 		ctx.font = `700 ${cntPx}px ${CV_FONT}`;
 		ctx.textAlign = "right";
-		ctx.fillText(`${t.count}`, playsEdge, titleBase(ry));
+		if (t.count > 0) ctx.fillText(`${t.count}`, playsEdge, titleBase(ry));
 		ctx.fillStyle = palette.dimText;
 		ctx.font = `600 ${playsLblPx}px ${CV_FONT}`;
 		ctx.letterSpacing = "0.06em";
-		ctx.fillText("PLAYS", playsEdge, artistBase(ry));
+		if (t.count > 0) ctx.fillText("PLAYS", playsEdge, artistBase(ry));
 		ctx.letterSpacing = defaultLetterSpacing;
 		ctx.textAlign = "left";
 	}
@@ -1786,7 +1843,7 @@ async function drawWrappedCompactArtistRows(
 		ctx.fillText(cvTruncate(ctx, a.artistName, textAvail), textX, titleBase(ry));
 		ctx.fillStyle = palette.dimText;
 		ctx.font = `${subPx}px ${CV_FONT}`;
-		const sub = a.count === 1 ? "1 play" : `${formatNumber(a.count)} plays`;
+		const sub = a.count > 0 ? (a.count === 1 ? "1 play" : `${formatNumber(a.count)} plays`) : "";
 		ctx.fillText(cvTruncate(ctx, sub, textAvail), textX, subBase(ry));
 	}
 	return y + artists.length * (tileSz + rowGap);
@@ -1802,8 +1859,9 @@ async function drawWrappedCompactGenreRows(
 	opts: { barH: number; rowGap: number; labelMax: number; labelPx: number; pctPx: number },
 ): Promise<number> {
 	if (top.length === 0) return y;
-	const maxCount = top[0].count;
+	const maxCount = top[0].count || 1;
 	const totalCount = top.reduce((s, g) => s + g.count, 0);
+	if (totalCount === 0) return y;
 	y = cvKicker(ctx, "Top genres", x, y, palette, false, opts.labelPx + 4);
 	y += opts.rowGap > 12 ? 16 : 12;
 	const { barH, rowGap, labelMax, labelPx, pctPx } = opts;
@@ -1849,8 +1907,11 @@ async function drawWrappedContent(
 	const totalHours = Math.floor(stats.totalDuration / 3_600_000);
 	const peakLbl = formatShareSpecPeakHour(stats.peakHour);
 	const streak = allowStreak ? (stats.streak ?? 0) : 0;
-	let meta = `${formatNumber(stats.totalPlays)} plays · ${stats.uniqueArtistCount} artists · peak ${peakLbl}`;
-	if (streak > 0) meta += ` · ${streak}-day streak`;
+	let meta =
+		stats.totalPlays > 0
+			? `${formatNumber(stats.totalPlays)} plays · ${stats.uniqueArtistCount} artists · peak ${peakLbl}`
+			: "";
+	if (streak > 0 && stats.totalPlays > 0) meta += ` · ${streak}-day streak`;
 
 	ctx.textAlign = "left";
 	ctx.textBaseline = "alphabetic";
@@ -1975,7 +2036,10 @@ export async function renderShareCardCanvas(
 	const allowStreak = providerId === "local";
 	const safeVariant = !allowStreak && variant === "streak" ? "top5" : variant;
 
-	const captionText = username ? `@${username} · ${periodLabel}` : periodLabel;
+	const captionParts: string[] = [];
+	if (options?.showUsername !== false && username) captionParts.push(`@${username}`);
+	if (options?.showPeriodLabel !== false) captionParts.push(periodLabel);
+	const captionText = captionParts.length > 0 ? captionParts.join(" · ") : "";
 
 	drawBackground(ctx, w, h, palette);
 	drawWatermarkBar(ctx, w, captionText, palette);

--- a/src/app/components/TopGenres.tsx
+++ b/src/app/components/TopGenres.tsx
@@ -1,12 +1,14 @@
 import type { TopGenre } from "../../shared/types/stats";
+import { ShareIcon } from "../icons";
 
 interface TopGenresProps {
 	topGenres: TopGenre[];
 	onGenreClick?: (genre: string) => void;
 	activeGenre?: string | null;
+	onShare?: () => void;
 }
 
-export function TopGenres({ topGenres, onGenreClick, activeGenre }: TopGenresProps) {
+export function TopGenres({ topGenres, onGenreClick, activeGenre, onShare }: TopGenresProps) {
 	if (!topGenres || topGenres.length === 0) return null;
 
 	const genres = topGenres.slice(0, 6);
@@ -17,6 +19,19 @@ export function TopGenres({ topGenres, onGenreClick, activeGenre }: TopGenresPro
 			<header className="section-heading">
 				<span className="section-kicker">Composition</span>
 				<h2 className="section-title">Top Genres</h2>
+				{onShare && (
+					<button
+						type="button"
+						className="btn-icon share-section-btn"
+						style={{ marginLeft: "auto" }}
+						onClick={(e) => {
+							e.stopPropagation();
+							onShare();
+						}}
+						aria-label="Share genres"
+						dangerouslySetInnerHTML={{ __html: ShareIcon }}
+					/>
+				)}
 			</header>
 			<div className="top-genres-list">
 				{genres.map((genre, i) => {

--- a/src/app/components/TopLists.tsx
+++ b/src/app/components/TopLists.tsx
@@ -1,6 +1,7 @@
 import type { StatsResult } from "../../shared/types/stats";
 import { normalizeSpotifyImageUrl } from "../../shared/util/spotify-image-url";
 import { formatDuration, formatNumber } from "../format";
+import { ShareIcon } from "../icons";
 import { getPreferences } from "../preferences";
 import { navigateToUri } from "../utils";
 import { SkeletonBlock, SkeletonCircle } from "./SkeletonPrimitives";
@@ -38,6 +39,11 @@ interface TopListsProps {
 	hiddenSections: string[];
 	onGenreClick?: (genre: string) => void;
 	activeGenre?: string | null;
+	onShare?: {
+		tracks?: () => void;
+		artists?: () => void;
+		albums?: () => void;
+	};
 }
 
 export function TopLists({
@@ -47,6 +53,7 @@ export function TopLists({
 	hiddenSections,
 	onGenreClick,
 	activeGenre,
+	onShare,
 }: TopListsProps) {
 	const prefs = getPreferences();
 
@@ -59,6 +66,19 @@ export function TopLists({
 				<header className="section-heading">
 					<span className="section-kicker">Most played</span>
 					<h2 className="section-title">Tracks</h2>
+					{onShare?.tracks && (
+						<button
+							type="button"
+							className="btn-icon share-section-btn"
+							style={{ marginLeft: "auto" }}
+							onClick={(e) => {
+								e.stopPropagation();
+								onShare.tracks?.();
+							}}
+							aria-label="Share top tracks"
+							dangerouslySetInnerHTML={{ __html: ShareIcon }}
+						/>
+					)}
 				</header>
 				{loading || loadingByColumn?.tracks ? (
 					<TopListColumnSkeleton />
@@ -135,6 +155,19 @@ export function TopLists({
 				<header className="section-heading">
 					<span className="section-kicker">Top</span>
 					<h2 className="section-title">Artists</h2>
+					{onShare?.artists && (
+						<button
+							type="button"
+							className="btn-icon share-section-btn"
+							style={{ marginLeft: "auto" }}
+							onClick={(e) => {
+								e.stopPropagation();
+								onShare.artists?.();
+							}}
+							aria-label="Share top artists"
+							dangerouslySetInnerHTML={{ __html: ShareIcon }}
+						/>
+					)}
 				</header>
 				{loading || loadingByColumn?.artists ? (
 					<TopListColumnSkeleton />
@@ -229,6 +262,19 @@ export function TopLists({
 				<header className="section-heading">
 					<span className="section-kicker">Top</span>
 					<h2 className="section-title">Albums</h2>
+					{onShare?.albums && (
+						<button
+							type="button"
+							className="btn-icon share-section-btn"
+							style={{ marginLeft: "auto" }}
+							onClick={(e) => {
+								e.stopPropagation();
+								onShare.albums?.();
+							}}
+							aria-label="Share top albums"
+							dangerouslySetInnerHTML={{ __html: ShareIcon }}
+						/>
+					)}
 				</header>
 				{loading || loadingByColumn?.albums ? (
 					<TopListColumnSkeleton />

--- a/src/app/hooks/useKonamiCode.ts
+++ b/src/app/hooks/useKonamiCode.ts
@@ -1,0 +1,44 @@
+const { useEffect, useRef } = Spicetify.React;
+
+const KONAMI = [
+	"ArrowUp",
+	"ArrowUp",
+	"ArrowDown",
+	"ArrowDown",
+	"ArrowLeft",
+	"ArrowRight",
+	"ArrowLeft",
+	"ArrowRight",
+	"b",
+	"a",
+];
+
+export function useKonamiCode(onActivate: () => void): void {
+	const idxRef = useRef(0);
+	const timerRef = useRef<ReturnType<typeof setTimeout>>();
+
+	useEffect(() => {
+		const handler = (e: KeyboardEvent) => {
+			const expected = KONAMI[idxRef.current];
+			if (e.key.toLowerCase() !== expected.toLowerCase()) {
+				idxRef.current = 0;
+				return;
+			}
+			idxRef.current++;
+			clearTimeout(timerRef.current);
+			timerRef.current = setTimeout(() => {
+				idxRef.current = 0;
+			}, 2000);
+
+			if (idxRef.current === KONAMI.length) {
+				idxRef.current = 0;
+				onActivate();
+			}
+		};
+		window.addEventListener("keydown", handler);
+		return () => {
+			window.removeEventListener("keydown", handler);
+			clearTimeout(timerRef.current);
+		};
+	}, [onActivate]);
+}

--- a/src/app/preferences.ts
+++ b/src/app/preferences.ts
@@ -72,6 +72,8 @@ export interface Preferences {
 	 * Empty string means no snapshot (toggle on, or hidden while no banner). New dismiss key → auto show again.
 	 */
 	announcementBannerHiddenForDismissKey: string;
+	/** Show @username caption on share cards */
+	showShareCaption: boolean;
 }
 
 const VALID_ACTIVITY_TABS = new Set<ActivityTabId>(["hour", "weekday", "day"]);
@@ -95,6 +97,7 @@ const DEFAULTS: Preferences = {
 	receiveBetaUpdates: false,
 	showAnnouncementBanner: true,
 	announcementBannerHiddenForDismissKey: "",
+	showShareCaption: true,
 };
 
 /**

--- a/src/app/styles.css
+++ b/src/app/styles.css
@@ -258,6 +258,11 @@ button.announcement-banner-link-btn:hover {
 	height: 20px;
 }
 
+/* Section-level share buttons hidden  -  header share button is sufficient */
+.share-section-btn {
+	display: none;
+}
+
 .loading-status-banner {
 	display: inline-flex;
 	align-items: center;
@@ -1619,6 +1624,7 @@ button.announcement-banner-link-btn:hover {
 
 .heatmap-scroll-inner {
 	min-width: min-content;
+	margin: 0 auto;
 }
 
 .heatmap-month-labels {
@@ -1650,7 +1656,7 @@ button.announcement-banner-link-btn:hover {
 .heatmap-legend {
 	display: flex;
 	align-items: center;
-	justify-content: flex-end;
+	justify-content: center;
 	gap: 6px;
 	margin-top: 10px;
 	font-size: 11px;
@@ -1662,6 +1668,94 @@ button.announcement-banner-link-btn:hover {
 	width: 16px;
 	height: 16px;
 	border-radius: 3px;
+}
+
+/* Drop-line indicators shown during section reorder drag */
+.dashboard-drop-line {
+	height: 3px;
+	margin: 0;
+	background: var(--spice-button-active);
+	border-radius: 2px;
+	opacity: 0;
+	transition:
+		opacity 120ms ease,
+		box-shadow 120ms ease;
+	pointer-events: none;
+}
+[data-drag-active] .dashboard-drop-line {
+	opacity: 0.2;
+}
+[data-drag-active] .dashboard-drop-line[data-active] {
+	opacity: 1;
+	box-shadow: 0 0 8px var(--spice-button-active);
+}
+
+/* Dashboard drag-handle for section reorder */
+.dashboard-section-row {
+	display: flex;
+	align-items: stretch;
+	gap: 6px;
+}
+
+.dashboard-drag-handle {
+	flex: 0 0 auto;
+	width: 20px;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	padding: 0;
+	background: transparent;
+	border: none;
+	cursor: grab;
+	color: rgba(var(--spice-rgb-text), 0.2);
+	border-radius: 4px;
+	margin-top: 20px;
+	transition:
+		color 0.15s,
+		background 0.15s;
+}
+.dashboard-drag-handle:hover {
+	color: rgba(var(--spice-rgb-text), 0.6);
+	background: rgba(var(--spice-rgb-misc, 128, 128, 128), 0.08);
+}
+.dashboard-drag-handle:active {
+	cursor: grabbing;
+	color: var(--spice-text);
+}
+
+.dashboard-section-content {
+	flex: 1;
+	min-width: 0;
+}
+
+/* Confetti overlay */
+.confetti-overlay {
+	position: fixed;
+	inset: 0;
+	pointer-events: none;
+	z-index: 9999;
+	overflow: hidden;
+}
+
+.confetti-particle {
+	position: absolute;
+	top: -10px;
+	border-radius: 2px;
+	animation: confetti-fall linear forwards;
+}
+
+@keyframes confetti-fall {
+	0% {
+		transform: translateY(0) translateX(0) rotate(0deg);
+		opacity: 1;
+	}
+	80% {
+		opacity: 1;
+	}
+	100% {
+		transform: translateY(100vh) translateX(40px) rotate(720deg);
+		opacity: 0;
+	}
 }
 
 /* Streak callout */
@@ -2571,8 +2665,8 @@ button.announcement-banner-link-btn:hover {
 	display: flex;
 	justify-content: center;
 	align-items: center;
-	min-height: 260px;
-	max-height: min(58vh, 640px);
+	height: min(58vh, 640px);
+	min-height: 320px;
 	overflow: auto;
 	padding: 16px;
 	border: 1px solid rgba(var(--spice-rgb-misc, 255, 255, 255), 0.1);

--- a/src/shared/stats/periods.ts
+++ b/src/shared/stats/periods.ts
@@ -35,6 +35,16 @@ function getAllTimeBoundaries(): PeriodBoundaries {
 	return { start: 0, end: Number.MAX_SAFE_INTEGER };
 }
 
+function getRolling4WeeksBoundaries(): PeriodBoundaries {
+	const now = Date.now();
+	return { start: now - 28 * 86400000, end: now };
+}
+
+function getRolling6MonthsBoundaries(): PeriodBoundaries {
+	const now = Date.now();
+	return { start: now - 180 * 86400000, end: now };
+}
+
 export const LOCAL_PERIODS: Period[] = [
 	{
 		id: "today",
@@ -67,8 +77,8 @@ export const LOCAL_PERIODS: Period[] = [
 // stats.fm API uses named range params (today/weeks/months/lifetime), not timestamps
 
 export const STATSFM_PERIODS: Period[] = [
-	{ id: "sfm-weeks", label: "This Week", getBoundaries: getThisWeekBoundaries },
-	{ id: "sfm-months", label: "This Month", getBoundaries: getThisMonthBoundaries },
+	{ id: "sfm-weeks", label: "Last 4 Weeks", getBoundaries: getRolling4WeeksBoundaries },
+	{ id: "sfm-months", label: "Last 6 Months", getBoundaries: getRolling6MonthsBoundaries },
 	{ id: "sfm-all-time", label: "All Time", getBoundaries: getAllTimeBoundaries },
 ];
 
@@ -90,13 +100,25 @@ export function getAdjacentPeriod(currentId: string): Period | null {
  * Feeds new-artist diff and hero vs-prior duration ratio.
  */
 export function getPriorPeriodBoundaries(period: Period): { start: number; end: number } | null {
-	if (period.id === "all-time" || period.id === "sfm-all-time") return null;
+	if (period.id === "all-time" || period.id === "sfm-all-time" || period.id === "overall") return null;
 	const { start, end } = period.getBoundaries();
 	const length = end - start;
 	const priorStart = start - length;
 	if (priorStart < 0) return null;
 	return { start: priorStart, end: start };
 }
+
+// Last.fm periods  -  API uses period param (7day / 1month / 3month / 6month / 12month / overall)
+// Boundaries kept for prior-window diff and local fallback use.
+
+export const LASTFM_PERIODS: Period[] = [
+	{ id: "7day", label: "7 Days", getBoundaries: () => ({ start: Date.now() - 7 * 86400000, end: Date.now() }) },
+	{ id: "1month", label: "1 Month", getBoundaries: () => ({ start: Date.now() - 30 * 86400000, end: Date.now() }) },
+	{ id: "3month", label: "3 Months", getBoundaries: () => ({ start: Date.now() - 90 * 86400000, end: Date.now() }) },
+	{ id: "6month", label: "6 Months", getBoundaries: () => ({ start: Date.now() - 180 * 86400000, end: Date.now() }) },
+	{ id: "12month", label: "12 Months", getBoundaries: () => ({ start: Date.now() - 365 * 86400000, end: Date.now() }) },
+	{ id: "overall", label: "Overall", getBoundaries: getAllTimeBoundaries },
+];
 
 /** Synthetic period tab: opens global charts (not persisted as a time range). */
 export const WORLD_TAB_PERIOD_ID = "world-charts";

--- a/src/test/share-modal.test.tsx
+++ b/src/test/share-modal.test.tsx
@@ -130,11 +130,11 @@ describe("ShareModal", () => {
 
 	it("shows follow theme toggle", async () => {
 		const { container } = await renderShareModal();
-		const toggle = document.querySelector<HTMLInputElement>(".share-toggle-row input[type='checkbox']");
+		const toggle = document.querySelector<HTMLButtonElement>(".share-control-row button[data-checked]");
 		expect(toggle).toBeTruthy();
-		expect(toggle?.checked).toBe(false);
+		expect(toggle?.getAttribute("data-checked")).toBe("false");
 		toggle?.click();
-		expect(toggle?.checked).toBe(true);
+		expect(toggle?.getAttribute("data-checked")).toBe("true");
 		Spicetify.ReactDOM.unmountComponentAtNode(container);
 		container.remove();
 	});

--- a/src/test/statsfm-periods.test.ts
+++ b/src/test/statsfm-periods.test.ts
@@ -26,16 +26,16 @@ describe("STATSFM_PERIODS array", () => {
 		}
 	});
 
-	it("sfm-weeks has label 'This Week'", () => {
+	it("sfm-weeks has label 'Last 4 Weeks'", () => {
 		const period = STATSFM_PERIODS.find((p) => p.id === "sfm-weeks");
 		expect(period).toBeDefined();
-		expect(period?.label).toBe("This Week");
+		expect(period?.label).toBe("Last 4 Weeks");
 	});
 
-	it("sfm-months has label 'This Month'", () => {
+	it("sfm-months has label 'Last 6 Months'", () => {
 		const period = STATSFM_PERIODS.find((p) => p.id === "sfm-months");
 		expect(period).toBeDefined();
-		expect(period?.label).toBe("This Month");
+		expect(period?.label).toBe("Last 6 Months");
 	});
 
 	it("sfm-all-time has label 'All Time'", () => {
@@ -91,27 +91,20 @@ describe("sfm-weeks boundaries", () => {
 		vi.useRealTimers();
 	});
 
-	it("at 2026-04-01 (Wednesday), start/end match LOCAL_PERIODS 'this-week' boundaries", () => {
-		const sfmWeeks = STATSFM_PERIODS.find((p) => p.id === "sfm-weeks");
-		const localWeek = LOCAL_PERIODS.find((p) => p.id === "this-week");
-		expect(sfmWeeks).toBeDefined();
-		expect(localWeek).toBeDefined();
-		const sfmBounds = sfmWeeks!.getBoundaries();
-		const localBounds = localWeek!.getBoundaries();
-		expect(sfmBounds.start).toBe(localBounds.start);
-		expect(sfmBounds.end).toBe(localBounds.end);
-	});
-
-	it("start is Monday 2026-03-30 midnight", () => {
+	it("at 2026-04-01, boundaries are a 28-day rolling window", () => {
 		const period = STATSFM_PERIODS.find((p) => p.id === "sfm-weeks");
 		expect(period).toBeDefined();
-		const { start } = period!.getBoundaries();
-		const startDate = new Date(start);
-		expect(startDate.getFullYear()).toBe(2026);
-		expect(startDate.getMonth()).toBe(2); // March = 2
-		expect(startDate.getDate()).toBe(30);
-		expect(startDate.getHours()).toBe(0);
-		expect(startDate.getMinutes()).toBe(0);
+		const { start, end } = period!.getBoundaries();
+		expect(end).toBeGreaterThan(start);
+		expect(end - start).toBe(28 * 24 * 60 * 60 * 1000);
+	});
+
+	it("end is now (April 1 2026 15:30)", () => {
+		const period = STATSFM_PERIODS.find((p) => p.id === "sfm-weeks");
+		expect(period).toBeDefined();
+		const { end } = period!.getBoundaries();
+		const now = new Date(2026, 3, 1, 15, 30, 0, 0).getTime();
+		expect(end).toBe(now);
 	});
 });
 
@@ -125,29 +118,20 @@ describe("sfm-months boundaries", () => {
 		vi.useRealTimers();
 	});
 
-	it("start/end match LOCAL_PERIODS 'this-month' boundaries", () => {
-		const sfmMonths = STATSFM_PERIODS.find((p) => p.id === "sfm-months");
-		const localMonth = LOCAL_PERIODS.find((p) => p.id === "this-month");
-		expect(sfmMonths).toBeDefined();
-		expect(localMonth).toBeDefined();
-		const sfmBounds = sfmMonths!.getBoundaries();
-		const localBounds = localMonth!.getBoundaries();
-		expect(sfmBounds.start).toBe(localBounds.start);
-		expect(sfmBounds.end).toBe(localBounds.end);
-	});
-
-	it("at 2026-04-01, start is April 1 midnight, end is May 1 midnight", () => {
+	it("at 2026-04-01, boundaries are a 180-day rolling window", () => {
 		const period = STATSFM_PERIODS.find((p) => p.id === "sfm-months");
 		expect(period).toBeDefined();
 		const { start, end } = period!.getBoundaries();
-		const startDate = new Date(start);
-		const endDate = new Date(end);
-		expect(startDate.getMonth()).toBe(3); // April
-		expect(startDate.getDate()).toBe(1);
-		expect(startDate.getHours()).toBe(0);
-		expect(endDate.getMonth()).toBe(4); // May
-		expect(endDate.getDate()).toBe(1);
-		expect(endDate.getHours()).toBe(0);
+		expect(end).toBeGreaterThan(start);
+		expect(end - start).toBe(180 * 24 * 60 * 60 * 1000);
+	});
+
+	it("end is now (April 1 2026 15:30)", () => {
+		const period = STATSFM_PERIODS.find((p) => p.id === "sfm-months");
+		expect(period).toBeDefined();
+		const { end } = period!.getBoundaries();
+		const now = new Date(2026, 3, 1, 15, 30, 0, 0).getTime();
+		expect(end).toBe(now);
 	});
 });
 


### PR DESCRIPTION
## Summary

A batch of UX improvements and fixes for the dashboard, share modal, and stats period handling.

### Share Modal
- Replaced HTML checkbox toggles with native **Spicetify `Toggle`** components for consistent styling with the Spotify client
- Added `showShareCaption` preference (toggle on share cards to show/hide @username caption)
- Fixed preview container sizing to avoid clipping

### Dashboard Section Reordering
- Added **6-dot grip handles** on the left side of each dashboard section
- Drag-to-reorder sections with a **drop-line preview** that highlights the insertion point
- Drop-lines only render during active drag (no ghost lines at rest)

### Period Labels & Boundaries (stats.fm)
- Updated period labels: "This Week" → **"Last 4 Weeks"**, "This Month" → **"Last 6 Months"**
- Changed boundaries from calendar week/month to rolling **28-day** and **180-day** windows
- Fixes Issue #43 

### Easter Egg
- Added a little Easter Egg with Keyboard Inputs

### Additional Changes
- Heatmap legend and container now center properly on fullscreen
- Removed unused imports, replaced `any` types with proper interfaces, fixed formatting

## Testing
- `npm run lint` — clean
- `npm run typecheck` — clean
- `npm test` — 75 test files / 1188 tests all passing

## Notes
- Spotify/ZIP import feature is being worked on separately and is **not** included in this PR.
- Section share buttons are present in code but hidden via CSS. They can be unhidden via a future preference toggle if desired.