### PR TITLE
feat: rolling-window periods for statsfm + LASTFM_PERIODS export

### DIFF
--- a/src/shared/stats/periods.ts
+++ b/src/shared/stats/periods.ts
@@ -31,6 +31,16 @@ function getLast6MonthsBoundaries(): PeriodBoundaries {
 	return { start: start.getTime(), end: end.getTime() };
 }
 
+function getRolling4WeeksBoundaries(): PeriodBoundaries {
+	const now = Date.now();
+	return { start: now - 28 * 86400000, end: now };
+}
+
+function getRolling6MonthsBoundaries(): PeriodBoundaries {
+	const now = Date.now();
+	return { start: now - 180 * 86400000, end: now };
+}
+
 function getAllTimeBoundaries(): PeriodBoundaries {
 	return { start: 0, end: Number.MAX_SAFE_INTEGER };
 }
@@ -67,8 +77,8 @@ export const LOCAL_PERIODS: Period[] = [
 // stats.fm API uses named range params (today/weeks/months/lifetime), not timestamps
 
 export const STATSFM_PERIODS: Period[] = [
-	{ id: "sfm-weeks", label: "This Week", getBoundaries: getThisWeekBoundaries },
-	{ id: "sfm-months", label: "This Month", getBoundaries: getThisMonthBoundaries },
+	{ id: "sfm-weeks", label: "Last 4 Weeks", getBoundaries: getRolling4WeeksBoundaries },
+	{ id: "sfm-months", label: "Last 6 Months", getBoundaries: getRolling6MonthsBoundaries },
 	{ id: "sfm-all-time", label: "All Time", getBoundaries: getAllTimeBoundaries },
 ];
 
@@ -90,13 +100,25 @@ export function getAdjacentPeriod(currentId: string): Period | null {
  * Feeds new-artist diff and hero vs-prior duration ratio.
  */
 export function getPriorPeriodBoundaries(period: Period): { start: number; end: number } | null {
-	if (period.id === "all-time" || period.id === "sfm-all-time") return null;
+	if (period.id === "all-time" || period.id === "sfm-all-time" || period.id === "overall") return null;
 	const { start, end } = period.getBoundaries();
 	const length = end - start;
 	const priorStart = start - length;
 	if (priorStart < 0) return null;
 	return { start: priorStart, end: start };
 }
+
+// Last.fm periods  -  API uses period param (7day / 1month / 3month / 6month / 12month / overall)
+// Boundaries kept for prior-window diff and local fallback use.
+
+export const LASTFM_PERIODS: Period[] = [
+	{ id: "7day", label: "7 Days", getBoundaries: () => ({ start: Date.now() - 7 * 86400000, end: Date.now() }) },
+	{ id: "1month", label: "1 Month", getBoundaries: () => ({ start: Date.now() - 30 * 86400000, end: Date.now() }) },
+	{ id: "3month", label: "3 Months", getBoundaries: () => ({ start: Date.now() - 90 * 86400000, end: Date.now() }) },
+	{ id: "6month", label: "6 Months", getBoundaries: () => ({ start: Date.now() - 180 * 86400000, end: Date.now() }) },
+	{ id: "12month", label: "12 Months", getBoundaries: () => ({ start: Date.now() - 365 * 86400000, end: Date.now() }) },
+	{ id: "overall", label: "Overall", getBoundaries: getAllTimeBoundaries },
+];
 
 /** Synthetic period tab: opens global charts (not persisted as a time range). */
 export const WORLD_TAB_PERIOD_ID = "world-charts";

--- a/src/test/statsfm-periods.test.ts
+++ b/src/test/statsfm-periods.test.ts
@@ -26,16 +26,16 @@ describe("STATSFM_PERIODS array", () => {
 		}
 	});
 
-	it("sfm-weeks has label 'This Week'", () => {
+	it("sfm-weeks has label 'Last 4 Weeks'", () => {
 		const period = STATSFM_PERIODS.find((p) => p.id === "sfm-weeks");
 		expect(period).toBeDefined();
-		expect(period?.label).toBe("This Week");
+		expect(period?.label).toBe("Last 4 Weeks");
 	});
 
-	it("sfm-months has label 'This Month'", () => {
+	it("sfm-months has label 'Last 6 Months'", () => {
 		const period = STATSFM_PERIODS.find((p) => p.id === "sfm-months");
 		expect(period).toBeDefined();
-		expect(period?.label).toBe("This Month");
+		expect(period?.label).toBe("Last 6 Months");
 	});
 
 	it("sfm-all-time has label 'All Time'", () => {
@@ -91,27 +91,20 @@ describe("sfm-weeks boundaries", () => {
 		vi.useRealTimers();
 	});
 
-	it("at 2026-04-01 (Wednesday), start/end match LOCAL_PERIODS 'this-week' boundaries", () => {
-		const sfmWeeks = STATSFM_PERIODS.find((p) => p.id === "sfm-weeks");
-		const localWeek = LOCAL_PERIODS.find((p) => p.id === "this-week");
-		expect(sfmWeeks).toBeDefined();
-		expect(localWeek).toBeDefined();
-		const sfmBounds = sfmWeeks!.getBoundaries();
-		const localBounds = localWeek!.getBoundaries();
-		expect(sfmBounds.start).toBe(localBounds.start);
-		expect(sfmBounds.end).toBe(localBounds.end);
-	});
-
-	it("start is Monday 2026-03-30 midnight", () => {
+	it("at 2026-04-01, boundaries are a 28-day rolling window", () => {
 		const period = STATSFM_PERIODS.find((p) => p.id === "sfm-weeks");
 		expect(period).toBeDefined();
-		const { start } = period!.getBoundaries();
-		const startDate = new Date(start);
-		expect(startDate.getFullYear()).toBe(2026);
-		expect(startDate.getMonth()).toBe(2); // March = 2
-		expect(startDate.getDate()).toBe(30);
-		expect(startDate.getHours()).toBe(0);
-		expect(startDate.getMinutes()).toBe(0);
+		const { start, end } = period!.getBoundaries();
+		expect(end).toBeGreaterThan(start);
+		expect(end - start).toBe(28 * 24 * 60 * 60 * 1000);
+	});
+
+	it("end is now (April 1 2026 15:30)", () => {
+		const period = STATSFM_PERIODS.find((p) => p.id === "sfm-weeks");
+		expect(period).toBeDefined();
+		const { end } = period!.getBoundaries();
+		const now = new Date(2026, 3, 1, 15, 30, 0, 0).getTime();
+		expect(end).toBe(now);
 	});
 });
 
@@ -125,29 +118,20 @@ describe("sfm-months boundaries", () => {
 		vi.useRealTimers();
 	});
 
-	it("start/end match LOCAL_PERIODS 'this-month' boundaries", () => {
-		const sfmMonths = STATSFM_PERIODS.find((p) => p.id === "sfm-months");
-		const localMonth = LOCAL_PERIODS.find((p) => p.id === "this-month");
-		expect(sfmMonths).toBeDefined();
-		expect(localMonth).toBeDefined();
-		const sfmBounds = sfmMonths!.getBoundaries();
-		const localBounds = localMonth!.getBoundaries();
-		expect(sfmBounds.start).toBe(localBounds.start);
-		expect(sfmBounds.end).toBe(localBounds.end);
-	});
-
-	it("at 2026-04-01, start is April 1 midnight, end is May 1 midnight", () => {
+	it("at 2026-04-01, boundaries are a 180-day rolling window", () => {
 		const period = STATSFM_PERIODS.find((p) => p.id === "sfm-months");
 		expect(period).toBeDefined();
 		const { start, end } = period!.getBoundaries();
-		const startDate = new Date(start);
-		const endDate = new Date(end);
-		expect(startDate.getMonth()).toBe(3); // April
-		expect(startDate.getDate()).toBe(1);
-		expect(startDate.getHours()).toBe(0);
-		expect(endDate.getMonth()).toBe(4); // May
-		expect(endDate.getDate()).toBe(1);
-		expect(endDate.getHours()).toBe(0);
+		expect(end).toBeGreaterThan(start);
+		expect(end - start).toBe(180 * 24 * 60 * 60 * 1000);
+	});
+
+	it("end is now (April 1 2026 15:30)", () => {
+		const period = STATSFM_PERIODS.find((p) => p.id === "sfm-months");
+		expect(period).toBeDefined();
+		const { end } = period!.getBoundaries();
+		const now = new Date(2026, 3, 1, 15, 30, 0, 0).getTime();
+		expect(end).toBe(now);
 	});
 });
 


### PR DESCRIPTION
**Description**

Replace calendar-aligned statsfm periods with rolling windows so data always reflects the most recent span:

- **"This Week" → "Last 4 Weeks"** (28-day rolling window) — No longer tied to the calendar week boundary.
- **"This Month" → "Last 6 Months"** (180-day rolling window) — Covers a meaningful listening history instead of a single calendar month.
- **`LASTFM_PERIODS` export** — New array with Last.fm API–compatible period IDs (`7day`, `1month`, `3month`, `6month`, `12month`, `overall`) and matching rolling boundaries for prior-window diff calculations.
- **Prior-period fix** — `getPriorPeriodBoundaries` now skips the `overall` period to avoid double-all-time comparisons.

**Type of Change**

- Enhancement / improvement

**How to Test**

- `npm install && npm run build`
- Deploy to Spicetify
- Open Listening Stats with statsfm provider
- Verify period tabs show "Last 4 Weeks" and "Last 6 Months"
- Verify data changes appropriately (not locked to calendar dates)
- Check prior-period comparisons (e.g. hero delta) still work

**Checklist**

- [x] Tested locally with `npm run build` (no errors)
- [x] All 1188 tests pass (`npx vitest run`)
- [x] TypeScript strict (`npx tsc --noEmit`)
- [x] No sensitive data included

**Files Changed**

- `src/shared/stats/periods.ts` — rolling boundary functions, `LASTFM_PERIODS`, prior-period skip
- `src/test/statsfm-periods.test.ts` — updated label and boundary assertions