### PR TITLE
feat: drag-to-reorder dashboard sections

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -41,6 +41,8 @@ import { TopGenres } from "./components/TopGenres";
 import { TopLists } from "./components/TopLists";
 import { UpdateModal } from "./components/UpdateModal";
 import { WorldChartsPage } from "./components/WorldChartsPage";
+import { useSettingsSortable } from "./hooks/useSettingsSortable";
+import { ChevronGripIcon } from "./icons";
 import { getPreferences, setPreference } from "./preferences";
 import { getTourSteps, shouldAutoStartTour } from "./tour";
 
@@ -292,6 +294,15 @@ function App() {
 	void prefsVersion;
 	const isHidden = (id: string) => prefs.hiddenSections.includes(id);
 
+	const sectionSortable = useSettingsSortable({
+		order: prefs.sectionOrder.filter((id) => availableSectionIds.has(id) && !isHidden(id)),
+		orientation: "vertical",
+		onReorder: (next) => {
+			setPreference("sectionOrder", next);
+			window.dispatchEvent(new CustomEvent(EVENTS.PREFS_CHANGED));
+		},
+	});
+
 	const handlePrefsChanged = useCallback(() => {
 		setPrefsVersion((v) => v + 1);
 	}, []);
@@ -482,9 +493,10 @@ function App() {
 			.filter(([, status]) => status === "loading" || status === "pending")
 			.map(([key]) => key);
 		const hasLoading = loadingSections.length > 0;
+		const { isDragging, dropSlotIndex } = sectionSortable.dragState;
 
 		return (
-			<div className="stats-page-content">
+			<div className="stats-page-content" data-drag-active={isDragging || undefined}>
 				{hasLoading && (
 					<div className="loading-status-banner" role="status" aria-live="polite">
 						<span className="loading-status-dot" />
@@ -493,14 +505,30 @@ function App() {
 						</span>
 					</div>
 				)}
-				{visibleSections.map((id) => {
+				{visibleSections.map((id, idx) => {
 					const content = renderSectionById(id);
-					return content ? (
-						<div key={id} data-section-id={id}>
-							{content}
-						</div>
-					) : null;
+					const dragStyle = sectionSortable.getItemStyle(id);
+					return (
+						<Spicetify.React.Fragment key={id}>
+							<div className="dashboard-drop-line" data-active={dropSlotIndex === idx || undefined} />
+							{content ? (
+								<div data-section-id={id} ref={(el) => sectionSortable.registerItem(id, el)} style={dragStyle}>
+									<div className="dashboard-section-row">
+										<button
+											type="button"
+											className="dashboard-drag-handle"
+											aria-label="Drag section"
+											onPointerDown={(e) => sectionSortable.onItemPointerDown(id)(e.nativeEvent)}
+											dangerouslySetInnerHTML={{ __html: ChevronGripIcon }}
+										/>
+										<div className="dashboard-section-content">{content}</div>
+									</div>
+								</div>
+							) : null}
+						</Spicetify.React.Fragment>
+					);
 				})}
+				<div className="dashboard-drop-line" data-active={dropSlotIndex === visibleSections.length || undefined} />
 			</div>
 		);
 	};

--- a/src/app/styles.css
+++ b/src/app/styles.css
@@ -1664,6 +1664,64 @@ button.announcement-banner-link-btn:hover {
 	border-radius: 3px;
 }
 
+/* Drop-line indicators shown during section reorder drag */
+.dashboard-drop-line {
+	height: 3px;
+	margin: 0;
+	background: var(--spice-button-active);
+	border-radius: 2px;
+	opacity: 0;
+	transition:
+		opacity 120ms ease,
+		box-shadow 120ms ease;
+	pointer-events: none;
+}
+[data-drag-active] .dashboard-drop-line {
+	opacity: 0.2;
+}
+[data-drag-active] .dashboard-drop-line[data-active] {
+	opacity: 1;
+	box-shadow: 0 0 8px var(--spice-button-active);
+}
+
+/* Dashboard drag-handle for section reorder */
+.dashboard-section-row {
+	display: flex;
+	align-items: stretch;
+	gap: 6px;
+}
+
+.dashboard-drag-handle {
+	flex: 0 0 auto;
+	width: 20px;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	padding: 0;
+	background: transparent;
+	border: none;
+	cursor: grab;
+	color: rgba(var(--spice-rgb-text), 0.2);
+	border-radius: 4px;
+	margin-top: 20px;
+	transition:
+		color 0.15s,
+		background 0.15s;
+}
+.dashboard-drag-handle:hover {
+	color: rgba(var(--spice-rgb-text), 0.6);
+	background: rgba(var(--spice-rgb-misc, 128, 128, 128), 0.08);
+}
+.dashboard-drag-handle:active {
+	cursor: grabbing;
+	color: var(--spice-text);
+}
+
+.dashboard-section-content {
+	flex: 1;
+	min-width: 0;
+}
+
 /* Streak callout */
 .streak-callout {
 	margin-top: 14px;


### PR DESCRIPTION
**Description**

Enable drag-to-reorder for dashboard sections using the existing `useSettingsSortable` hook:

- **Drag handle** — Each section gets a grip handle (ChevronGripIcon) on the left side. Hover reveals the handle; cursor changes to `grab`/`grabbing`.
- **Drop indicators** — Translucent drop-line elements appear between sections during a drag, with the active slot highlighted.
- **Persistence** — The new section order is saved to the `sectionOrder` preference immediately on reorder via `setPreference`.

**Type of Change**

- New feature

**How to Test**

- `npm install && npm run build`
- Deploy to Spicetify
- Open Listening Stats dashboard
- Hover any section — the grip handle should appear
- Drag a section up or down — drop lines should indicate the target position
- Refresh the page — the custom order should persist

**Checklist**

- [x] Tested locally with `npm run build` (no errors)
- [x] All 1188 tests pass (`npx vitest run`)
- [x] TypeScript strict (`npx tsc --noEmit`)
- [x] No sensitive data included

**Files Changed**

- `src/app/App.tsx` — `useSettingsSortable` integration, drag UI rendering, data attributes
- `src/app/styles.css` — `.dashboard-*` classes for drag handle, drop lines, section layout