### PR TITLE
chore: fix formatting and import sorting

### DIFF
--- a/src/app/components/LoadingSkeleton.tsx
+++ b/src/app/components/LoadingSkeleton.tsx
@@ -37,10 +37,7 @@ export function TopListsWaveSkeleton() {
 				>
 					<SkeletonBlock width="80px" height="14px" style={{ marginBottom: "14px" }} />
 					{Array.from({ length: 5 }).map((_, row) => (
-						<div
-							key={row}
-							style={{ display: "flex", gap: "10px", alignItems: "center", marginBottom: "10px" }}
-						>
+						<div key={row} style={{ display: "flex", gap: "10px", alignItems: "center", marginBottom: "10px" }}>
 							<SkeletonCircle size={20} style={{ flexShrink: 0 }} />
 							<SkeletonBlock width="36px" height="36px" style={{ flexShrink: 0 }} />
 							<div style={{ flex: 1 }}>
@@ -79,10 +76,7 @@ export function WorldChartsSkeleton() {
 					<div className="skeleton-shimmer" style={{ width: "40%", height: 14, margin: "14px 18px 10px" }} />
 					<div>
 						{Array.from({ length: 6 }).map((_, row) => (
-							<div
-								key={row}
-								style={{ display: "flex", gap: 12, alignItems: "center", padding: "8px 12px" }}
-							>
+							<div key={row} style={{ display: "flex", gap: 12, alignItems: "center", padding: "8px 12px" }}>
 								<div className="skeleton-shimmer" style={{ width: 20, height: 20, borderRadius: 4, flexShrink: 0 }} />
 								<div
 									className="skeleton-shimmer skeleton-tile"
@@ -98,10 +92,7 @@ export function WorldChartsSkeleton() {
 											borderRadius: "4px",
 										}}
 									/>
-									<div
-										className="skeleton-shimmer"
-										style={{ width: "50%", height: "10px", borderRadius: "4px" }}
-									/>
+									<div className="skeleton-shimmer" style={{ width: "50%", height: "10px", borderRadius: "4px" }} />
 								</div>
 							</div>
 						))}
@@ -116,11 +107,7 @@ export function ActivityChartSkeleton() {
 	return (
 		<div className="activity-chart" aria-hidden="true">
 			{Array.from({ length: 24 }).map((_, i) => (
-				<div
-					key={i}
-					className="activity-bar skeleton-shimmer"
-					style={{ height: `${20 + Math.random() * 60}%` }}
-				/>
+				<div key={i} className="activity-bar skeleton-shimmer" style={{ height: `${20 + Math.random() * 60}%` }} />
 			))}
 		</div>
 	);

--- a/src/app/components/WorldChartsPage.tsx
+++ b/src/app/components/WorldChartsPage.tsx
@@ -10,7 +10,7 @@ import {
 } from "../world-charts-service";
 import { InlineErrorCard } from "./InlineErrorCard";
 import { WorldChartsSkeleton } from "./LoadingSkeleton";
-import { ChartCard, HeroSkeleton, WorldHeroSection, WorldWindowTabs, WORLD_WINDOWS } from "./world/WorldSpotlightUi";
+import { ChartCard, HeroSkeleton, WORLD_WINDOWS, WorldHeroSection, WorldWindowTabs } from "./world/WorldSpotlightUi";
 
 const { useState, useEffect, useCallback } = Spicetify.React;
 

--- a/src/app/components/world/WorldSpotlightUi.tsx
+++ b/src/app/components/world/WorldSpotlightUi.tsx
@@ -1,7 +1,7 @@
 import type { WorldChartKind, WorldIndicator, WorldTrack, WorldWindow } from "../../../shared/types/world-charts";
 import { formatDuration } from "../../world-charts-service";
-import { getRankClass } from "../TopLists";
 import { navigateWorldItem, playOrOpenWorldTrack, trackPlayTooltip } from "../../world-spotify-actions";
+import { getRankClass } from "../TopLists";
 
 const { useMemo } = Spicetify.React;
 
@@ -183,15 +183,7 @@ function asideCardMeta(item: WorldTrack, kind: WorldChartKind) {
 	return { title: item.title, sub: item.artist ? `${item.artist}${year}` : "", stat: item.plays, art };
 }
 
-function HeroAsideCard({
-	label,
-	item,
-	kind,
-}: {
-	label: string;
-	item: WorldTrack;
-	kind: WorldChartKind;
-}) {
+function HeroAsideCard({ label, item, kind }: { label: string; item: WorldTrack; kind: WorldChartKind }) {
 	const meta = asideCardMeta(item, kind);
 	return (
 		<button type="button" className="world-aside-card" onClick={() => navigateWorldItem(item, kind)}>
@@ -373,7 +365,10 @@ export function ChartCard({
 }) {
 	const all = [...podium, ...rows];
 	return (
-		<section className="section-card" data-section={kind === "track" ? "tracks" : kind === "artist" ? "artists" : "albums"}>
+		<section
+			className="section-card"
+			data-section={kind === "track" ? "tracks" : kind === "artist" ? "artists" : "albums"}
+		>
 			<header className="section-heading">
 				<span className="section-kicker">{kicker}</span>
 				<h2 className="section-title">{title}</h2>

--- a/src/app/world-charts-service.ts
+++ b/src/app/world-charts-service.ts
@@ -510,10 +510,7 @@ export function getCharts(_scope: WorldScope, _window: WorldWindow): WorldTrack[
 	return [...WORLD_TRACKS];
 }
 
-export async function getChartsAsync(
-	_scope: WorldScope,
-	window: WorldWindow,
-): Promise<WorldChartResult<WorldTrack[]>> {
+export async function getChartsAsync(_scope: WorldScope, window: WorldWindow): Promise<WorldChartResult<WorldTrack[]>> {
 	if (!isStatsFmWindowSupported(window)) return unsupportedWindowResult(window);
 	const range = RANGE_BY_WINDOW[window] ?? "today";
 	try {

--- a/src/app/world-spotify-actions.ts
+++ b/src/app/world-spotify-actions.ts
@@ -130,9 +130,7 @@ function pickSpotifySearchMatch(items: SpotifySearchTrack[], title: string, arti
 
 async function searchSpotifyTrackId(title: string, artist: string): Promise<string | null> {
 	const primary = primaryArtistName(artist);
-	const queries = primary
-		? [`track:${title} artist:${primary}`, `${title} ${primary}`]
-		: [title];
+	const queries = primary ? [`track:${title} artist:${primary}`, `${title} ${primary}`] : [title];
 
 	for (const q of queries) {
 		const result = await cosmosGet<SpotifySearchResponse>(

--- a/src/shared/types/world-charts.ts
+++ b/src/shared/types/world-charts.ts
@@ -31,4 +31,3 @@ export type WorldWindow = "today" | "week" | "month" | "lifetime";
 export type WorldChartDataSource = "statsfm" | "mytopspotify" | "mock";
 
 export type WorldChartKind = "track" | "artist" | "album";
-

--- a/src/test/world-spotify-actions.test.ts
+++ b/src/test/world-spotify-actions.test.ts
@@ -5,7 +5,6 @@ vi.mock("../shared/api/cosmos-async", () => ({
 	cosmosGet: vi.fn(),
 }));
 
-import { cosmosGet } from "../shared/api/cosmos-async";
 import {
 	enrichTracksWithSpotifyIds,
 	navigateWorldItem,
@@ -13,6 +12,7 @@ import {
 	playWorldTrack,
 	spotifyTrackUri,
 } from "../app/world-spotify-actions";
+import { cosmosGet } from "../shared/api/cosmos-async";
 
 const cosmosGetMock = vi.mocked(cosmosGet);
 


### PR DESCRIPTION
Run `biome check --write src` to fix pre-existing formatting and import sorting issues across the codebase. This ensures the CI lint workflow passes.

Files changed:
- LoadingSkeleton.tsx
- WorldChartsPage.tsx
- WorldSpotlightUi.tsx
- world-charts-service.ts
- world-spotify-actions.ts
- world-charts.ts
- world-spotify-actions.test.ts
- pnpm-workspace.yaml (added)