### PR TITLE
fix: stop vitest from running stale test copies in dist/

### DIFF
--- a/src/app/components/ThresholdSlider.tsx
+++ b/src/app/components/ThresholdSlider.tsx
@@ -1,0 +1,89 @@
+interface ThresholdSliderProps {
+	/** Slider range is 0..max in whole units (seconds or percent) */
+	max: number;
+	value: number;
+	/** Clicking a preset label snaps to it */
+	presets: number[];
+	onChange: (value: number) => void;
+	formatValue: (value: number) => string;
+}
+
+/**
+ * Slider for the play threshold. The green value box is draggable for custom
+ * values (whole units only); the preset labels underneath snap on click.
+ */
+export function ThresholdSlider({ max, value, presets, onChange, formatValue }: ThresholdSliderProps) {
+	const React = Spicetify.React;
+	const railRef = React.useRef<HTMLDivElement | null>(null);
+
+	const valueFromClientX = (clientX: number): number => {
+		const rail = railRef.current;
+		if (!rail) return value;
+		const rect = rail.getBoundingClientRect();
+		if (rect.width <= 0) return value;
+		const ratio = (clientX - rect.left) / rect.width;
+		return Math.max(0, Math.min(max, Math.round(ratio * max)));
+	};
+
+	const handlePointerDown = (e: { currentTarget: HTMLDivElement; pointerId: number; clientX: number }) => {
+		e.currentTarget.setPointerCapture?.(e.pointerId);
+		onChange(valueFromClientX(e.clientX));
+	};
+
+	const handlePointerMove = (e: { currentTarget: HTMLDivElement; pointerId: number; clientX: number }) => {
+		if (!e.currentTarget.hasPointerCapture?.(e.pointerId)) return;
+		onChange(valueFromClientX(e.clientX));
+	};
+
+	const handleKeyDown = (e: { key: string; preventDefault: () => void }) => {
+		if (e.key === "ArrowLeft" || e.key === "ArrowDown") {
+			e.preventDefault();
+			onChange(Math.max(0, value - 1));
+		} else if (e.key === "ArrowRight" || e.key === "ArrowUp") {
+			e.preventDefault();
+			onChange(Math.min(max, value + 1));
+		}
+	};
+
+	const pct = max > 0 ? (value / max) * 100 : 0;
+
+	return (
+		<div className="threshold-slider">
+			<div
+				className="threshold-slider-rail"
+				ref={railRef}
+				onPointerDown={handlePointerDown}
+				onPointerMove={handlePointerMove}
+			>
+				<div className="threshold-slider-track" />
+				<div className="threshold-slider-fill" style={{ width: `${pct}%` }} />
+				<div
+					className="threshold-slider-handle"
+					style={{ left: `${pct}%` }}
+					role="slider"
+					tabIndex={0}
+					aria-valuemin={0}
+					aria-valuemax={max}
+					aria-valuenow={value}
+					aria-valuetext={formatValue(value)}
+					onKeyDown={handleKeyDown}
+				>
+					{formatValue(value)}
+				</div>
+			</div>
+			<div className="threshold-slider-presets">
+				{presets.map((preset) => (
+					<button
+						key={preset}
+						type="button"
+						className={`threshold-slider-preset${preset === value ? " active" : ""}`}
+						style={{ left: `${max > 0 ? (preset / max) * 100 : 0}%` }}
+						onClick={() => onChange(preset)}
+					>
+						{formatValue(preset)}
+					</button>
+				))}
+			</div>
+		</div>
+	);
+}

--- a/src/app/components/settings/TrackingTab.tsx
+++ b/src/app/components/settings/TrackingTab.tsx
@@ -1,17 +1,22 @@
 import {
 	getPlayThreshold,
+	getPlayThresholdPercent,
+	getThresholdMode,
 	isSkipRepeatsEnabled,
 	isTrackingPaused,
 	setPlayThreshold,
+	setPlayThresholdPercent,
 	setSkipRepeatsEnabled,
+	setThresholdMode,
 	setTrackingPaused,
 } from "../../../extension/tracker/settings";
 import { EVENTS } from "../../../shared/constants/events";
 import { LS_KEYS } from "../../../shared/constants/storage-keys";
-import { SegmentedControl } from "../SegmentedControl";
 import { Toggle } from "../spicetify-ui";
+import { ThresholdSlider } from "../ThresholdSlider";
 
-const THRESHOLD_STOPS = [0, 5000, 10000, 15000, 20000, 25000, 30000, 35000, 40000, 45000, 50000, 55000, 60000];
+const SECONDS_PRESETS = [0, 15, 30, 45, 60];
+const PERCENT_PRESETS = [0, 25, 50, 75, 100];
 
 const { useState } = Spicetify.React;
 
@@ -30,7 +35,9 @@ interface TrackingTabProps {
 export function TrackingTab({ onPrefsChanged }: TrackingTabProps) {
 	const [paused, setPaused] = useState(() => isTrackingPaused());
 	const [skipRepeats, setSkipRepeats] = useState(() => isSkipRepeatsEnabled());
-	const [threshold, setThreshold] = useState(() => getPlayThreshold());
+	const [percentMode, setPercentMode] = useState(() => getThresholdMode() === "percent");
+	const [thresholdSec, setThresholdSec] = useState(() => getPlayThreshold() / 1000);
+	const [thresholdPct, setThresholdPct] = useState(() => getPlayThresholdPercent());
 	const [logging, setLogging] = useState(() => isLoggingEnabled());
 
 	const handlePause = (val: boolean) => {
@@ -46,9 +53,20 @@ export function TrackingTab({ onPrefsChanged }: TrackingTabProps) {
 		onPrefsChanged();
 	};
 
+	const handlePercentMode = (val: boolean) => {
+		setPercentMode(val);
+		setThresholdMode(val ? "percent" : "seconds");
+		onPrefsChanged();
+	};
+
 	const handleThreshold = (val: number) => {
-		setThreshold(val);
-		setPlayThreshold(val);
+		if (percentMode) {
+			setThresholdPct(val);
+			setPlayThresholdPercent(val);
+		} else {
+			setThresholdSec(val);
+			setPlayThreshold(val * 1000);
+		}
 		onPrefsChanged();
 	};
 
@@ -86,17 +104,36 @@ export function TrackingTab({ onPrefsChanged }: TrackingTabProps) {
 				)}
 			</div>
 
+			{/* Threshold Mode */}
+			<div className="settings-row">
+				<div>
+					<div className="settings-label">Percentage Threshold</div>
+					<div className="settings-sublabel">Use a share of the track length instead of seconds</div>
+				</div>
+				{Toggle ? (
+					<Toggle value={percentMode} onSelected={handlePercentMode} />
+				) : (
+					<input type="checkbox" checked={percentMode} onChange={(e) => handlePercentMode(e.currentTarget.checked)} />
+				)}
+			</div>
+
 			{/* Play Threshold */}
 			<div className="settings-row" style={{ flexDirection: "column", alignItems: "stretch" }}>
 				<div style={{ marginBottom: "8px" }}>
 					<div className="settings-label">Play Threshold</div>
-					<div className="settings-sublabel">Minimum time to count a track as played</div>
+					<div className="settings-sublabel">
+						{percentMode
+							? "Minimum share of the track to count it as played"
+							: "Minimum time to count a track as played"}
+						{" — local tracking only; stats.fm and Last.fm use their own rules"}
+					</div>
 				</div>
-				<SegmentedControl
-					stops={THRESHOLD_STOPS}
-					value={threshold}
-					onSelect={handleThreshold}
-					labelAt={[0, 15000, 30000, 45000, 60000]}
+				<ThresholdSlider
+					max={percentMode ? 100 : 60}
+					value={percentMode ? thresholdPct : thresholdSec}
+					presets={percentMode ? PERCENT_PRESETS : SECONDS_PRESETS}
+					onChange={handleThreshold}
+					formatValue={(v) => (percentMode ? `${v}%` : `${v}s`)}
 				/>
 			</div>
 

--- a/src/app/styles.css
+++ b/src/app/styles.css
@@ -1685,49 +1685,88 @@ button.announcement-banner-link-btn:hover {
 	gap: 8px;
 }
 
-/* Segmented control */
-.segmented-control {
-	display: flex;
+/* Threshold slider */
+.threshold-slider {
+	padding: 10px 24px 26px;
+}
+
+.threshold-slider-rail {
 	position: relative;
+	height: 28px;
+	cursor: pointer;
+	touch-action: none;
+}
+
+.threshold-slider-track {
+	position: absolute;
+	left: 0;
+	right: 0;
+	top: 50%;
+	height: 4px;
+	transform: translateY(-50%);
+	border-radius: 2px;
 	background: var(--spice-card);
 	border: 1px solid var(--spice-misc);
-	border-radius: 4px;
-	height: 36px;
-	align-items: center;
-	width: 100%;
 }
 
-.segmented-control-stop {
-	flex: 1;
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	cursor: pointer;
+.threshold-slider-fill {
+	position: absolute;
+	left: 0;
+	top: 50%;
+	height: 4px;
+	transform: translateY(-50%);
+	border-radius: 2px;
+	background: var(--spice-button);
+	opacity: 0.5;
+	pointer-events: none;
+}
+
+.threshold-slider-handle {
+	position: absolute;
+	top: 50%;
+	transform: translate(-50%, -50%);
+	min-width: 40px;
+	padding: 3px 6px;
+	border-radius: 4px;
+	background: var(--spice-button);
+	color: var(--spice-main);
+	font-size: var(--font-size-sm, 12px);
+	font-weight: 700;
+	text-align: center;
+	user-select: none;
+	cursor: grab;
+	z-index: 1;
+}
+
+.threshold-slider-handle:active {
+	cursor: grabbing;
+}
+
+.threshold-slider-presets {
+	position: relative;
+	height: 16px;
+	margin-top: 6px;
+}
+
+.threshold-slider-preset {
+	position: absolute;
+	transform: translateX(-50%);
+	background: none;
+	border: none;
+	padding: 0;
 	font-size: var(--font-size-sm, 12px);
 	color: var(--spice-subtext);
-	z-index: 1;
-	transition: color 0.15s;
+	cursor: pointer;
 	user-select: none;
-	padding: 0 2px;
-	min-width: 0;
 }
 
-.segmented-control-stop.active {
+.threshold-slider-preset:hover {
+	color: var(--spice-text);
+}
+
+.threshold-slider-preset.active {
 	color: var(--spice-text);
 	font-weight: 700;
-}
-
-.segmented-control-indicator {
-	position: absolute;
-	top: 2px;
-	bottom: 2px;
-	border-radius: 3px;
-	background: var(--spice-button);
-	opacity: 0.85;
-	transition:
-		left 0.2s ease,
-		width 0.2s ease;
-	pointer-events: none;
 }
 
 /* ───────────────────────────────────────────────────────────────────────

--- a/src/extension/tracker/fsm.ts
+++ b/src/extension/tracker/fsm.ts
@@ -43,6 +43,8 @@ export interface FSMState {
 	lastProgressMs: number;
 	lastLoopDetectedAt: number;
 	lastRecordedUri: string | null;
+	/** DB id of the play event written when this track crossed the threshold, null if not yet written */
+	recordedEventId: number | null;
 }
 
 // Shape of PlayerData passed in from event handlers (subset of Spicetify.Player.data)
@@ -110,8 +112,12 @@ export function parseLocalFileUri(uri: string): { artist: string; album: string;
 // ─── Dependency Injection Interface ───────────────────────────────────────────
 
 export interface TrackingFSMDeps {
-	addPlayEvent: (event: PlayEvent) => Promise<boolean>;
-	getPlayThreshold: () => number;
+	/** Inserts a play event; returns the new event id, or null when deduped */
+	addPlayEvent: (event: PlayEvent) => Promise<number | null>;
+	/** Updates the final play time of an already-written event */
+	updatePlayEvent: (id: number, playedMs: number, endedAt: number) => Promise<void>;
+	/** Effective threshold in ms for a track (percent mode needs the duration) */
+	resolveThresholdMs: (durationMs: number) => number;
 	isTrackingPaused: () => boolean;
 	isSkipRepeatsEnabled: () => boolean;
 	dispatchEvent: (event: Event) => void;
@@ -140,6 +146,7 @@ export class TrackingFSM {
 			lastProgressMs: 0,
 			lastLoopDetectedAt: 0,
 			lastRecordedUri: null,
+			recordedEventId: null,
 		};
 	}
 
@@ -166,10 +173,7 @@ export class TrackingFSM {
 		// Write event for previous track if we were tracking
 		if (this._state.state === "tracking" && this._state.capturedData) {
 			this._state.state = "completing";
-			const totalPlayedMs =
-				this._state.accumulatedPlayMs +
-				(this._state.isPlaying && this._state.playStartTime !== null ? Date.now() - this._state.playStartTime : 0);
-			await this._writePlayEvent(totalPlayedMs);
+			await this._finalizePlayEvent(this._totalPlayedMs());
 		}
 
 		// Reset progress to prevent false loop detection after real track change
@@ -209,7 +213,10 @@ export class TrackingFSM {
 			this._state.playStartTime = Date.now();
 			this._state.accumulatedPlayMs = 0;
 			this._state.isPlaying = !playerData.isPaused;
+			this._state.recordedEventId = null;
 			this._state.state = "tracking";
+			// A 0s/0% threshold counts the play the moment the track starts
+			await this._maybeRecordThresholdCross();
 		} else {
 			// Transition to idle, clear all tracking state
 			this._state = {
@@ -234,6 +241,9 @@ export class TrackingFSM {
 				this._state.accumulatedPlayMs += Date.now() - this._state.playStartTime;
 			}
 			this._state.isPlaying = false;
+			// Record now if the banked time crossed the threshold — the user may
+			// close Spotify without the track ever ending or changing.
+			void this._maybeRecordThresholdCross();
 		} else if (!wasPlaying && !isPaused) {
 			// Resuming: reset start time
 			this._state.playStartTime = Date.now();
@@ -256,14 +266,11 @@ export class TrackingFSM {
 				// Loop detected  -  record completed play for this loop iteration
 				this._state.lastLoopDetectedAt = Date.now();
 
-				const totalPlayedMs =
-					this._state.accumulatedPlayMs +
-					(this._state.isPlaying && this._state.playStartTime !== null ? Date.now() - this._state.playStartTime : 0);
-
 				// Write and re-capture async (don't await in sync handler)
-				void this._writePlayEvent(totalPlayedMs).then(() => {
+				void this._finalizePlayEvent(this._totalPlayedMs()).then(() => {
 					// Reset accumulator for new loop
 					this._state.accumulatedPlayMs = 0;
+					this._state.recordedEventId = null;
 					if (this._state.isPlaying) {
 						this._state.playStartTime = Date.now();
 					}
@@ -279,6 +286,7 @@ export class TrackingFSM {
 		}
 
 		this._state.lastProgressMs = progressMs;
+		void this._maybeRecordThresholdCross();
 	}
 
 	/** Intentional no-op: tracking persists for the session. */
@@ -288,8 +296,81 @@ export class TrackingFSM {
 
 	// ─── Private ──────────────────────────────────────────────────────────────
 
-	private async _writePlayEvent(totalPlayedMs: number): Promise<void> {
+	private _crossWritePromise: Promise<void> | null = null;
+
+	/** Play time so far: banked time plus the current playing stretch */
+	private _totalPlayedMs(): number {
+		return (
+			this._state.accumulatedPlayMs +
+			(this._state.isPlaying && this._state.playStartTime !== null ? Date.now() - this._state.playStartTime : 0)
+		);
+	}
+
+	/**
+	 * Records the play the moment it crosses the threshold, so a track that is
+	 * paused and never "ends" (e.g. Spotify closed) is still counted. The final
+	 * play time is patched in later by _finalizePlayEvent.
+	 */
+	private async _maybeRecordThresholdCross(): Promise<void> {
+		if (this._state.state !== "tracking" || !this._state.capturedData) return;
+		if (this._state.recordedEventId !== null || this._crossWritePromise !== null) return;
+		if (this._deps.isTrackingPaused()) return;
+
+		const duration = this._state.capturedData.durationMs;
+		if (duration <= 0) return;
+
+		// Same rule as classifyPlayOrSkip: ~90% of the track always counts,
+		// even when the configured threshold is longer.
+		const effectiveMs = Math.min(this._deps.resolveThresholdMs(duration), duration * 0.9);
+		if (this._totalPlayedMs() < effectiveMs) return;
+
+		// Skip-repeats suppression: only suppress consecutive plays (not skips)
+		if (this._deps.isSkipRepeatsEnabled() && this._state.capturedData.trackUri === this._state.lastRecordedUri) {
+			return;
+		}
+
+		const write = (async () => {
+			try {
+				const id = await this._writeEvent("play", this._totalPlayedMs());
+				// 0 = deduped (already in DB from elsewhere): counts as recorded so we
+				// neither retry every progress tick nor patch a foreign event later.
+				this._state.recordedEventId = id ?? 0;
+			} catch (err) {
+				// Leave recordedEventId null: later ticks and the end-of-track write retry
+				console.warn("[listening-stats] Failed to write play event:", err);
+			}
+		})();
+		this._crossWritePromise = write;
+		try {
+			await write;
+		} finally {
+			this._crossWritePromise = null;
+		}
+	}
+
+	/**
+	 * Called when a track finishes (song change or repeat-one loop).
+	 * If the play was already recorded at threshold-cross, patches its final
+	 * play time; otherwise classifies play/skip and writes the event.
+	 */
+	private async _finalizePlayEvent(totalPlayedMs: number): Promise<void> {
 		if (!this._state.capturedData) return;
+
+		// A threshold-cross write may still be in flight; let it settle so we
+		// patch that event instead of writing a duplicate.
+		if (this._crossWritePromise !== null) await this._crossWritePromise;
+
+		if (this._state.recordedEventId !== null) {
+			// 0 = recorded-but-deduped: nothing of ours to patch
+			if (this._state.recordedEventId > 0) {
+				try {
+					await this._deps.updatePlayEvent(this._state.recordedEventId, totalPlayedMs, Date.now());
+				} catch (err) {
+					console.warn("[listening-stats] Failed to update play event:", err);
+				}
+			}
+			return;
+		}
 
 		if (this._deps.isTrackingPaused()) {
 			// Dispatch paused event but do NOT write; FSM state is preserved
@@ -297,9 +378,8 @@ export class TrackingFSM {
 			return;
 		}
 
-		const threshold = this._deps.getPlayThreshold();
-		const capturedDuration = this._state.capturedData.durationMs;
-		const eventType = classifyPlayOrSkip(totalPlayedMs, capturedDuration, threshold);
+		const threshold = this._deps.resolveThresholdMs(this._state.capturedData.durationMs);
+		const eventType = classifyPlayOrSkip(totalPlayedMs, this._state.capturedData.durationMs, threshold);
 
 		// Skip-repeats suppression: only suppress consecutive plays (not skips)
 		if (
@@ -310,6 +390,21 @@ export class TrackingFSM {
 			return;
 		}
 
+		try {
+			await this._writeEvent(eventType, totalPlayedMs);
+		} catch (err) {
+			// Log warning but do NOT crash the FSM
+			console.warn("[listening-stats] Failed to write play event:", err);
+		}
+	}
+
+	/**
+	 * Writes the event, updates skip-repeats state, dispatches, logs.
+	 * Returns the new id, null when deduped; throws on write failure.
+	 */
+	private async _writeEvent(eventType: "play" | "skip", totalPlayedMs: number): Promise<number | null> {
+		if (!this._state.capturedData) return null;
+
 		const event: PlayEvent = {
 			trackUri: this._state.capturedData.trackUri,
 			trackName: this._state.capturedData.trackName,
@@ -318,33 +413,29 @@ export class TrackingFSM {
 			albumName: this._state.capturedData.albumName,
 			albumUri: this._state.capturedData.albumUri,
 			albumArt: this._state.capturedData.albumArt,
-			durationMs: capturedDuration,
+			durationMs: this._state.capturedData.durationMs,
 			playedMs: totalPlayedMs,
 			startedAt: this._state.capturedData.startedAt,
 			endedAt: Date.now(),
 			type: eventType,
 		};
 
-		try {
-			const written = await this._deps.addPlayEvent(event);
-			if (written) {
-				// Update skip-repeats tracker for successful play writes
-				if (eventType === "play" && this._deps.isSkipRepeatsEnabled()) {
-					this._state.lastRecordedUri = this._state.capturedData.trackUri;
-				}
-				// Notify listeners (play vs skip)
-				const eventName = eventType === "play" ? EVENTS.PLAY_RECORDED : EVENTS.SKIP_RECORDED;
-				this._deps.dispatchEvent(new CustomEvent(eventName, { detail: event }));
-
-				if (localStorage.getItem(LS_KEYS.LOGGING) === "true") {
-					console.log(
-						`[listening-stats] ${eventType}: "${event.trackName}" by ${event.artistName} (${Math.round(event.playedMs / 1000)}s)`,
-					);
-				}
+		const id = await this._deps.addPlayEvent(event);
+		if (id !== null) {
+			// Update skip-repeats tracker for successful play writes
+			if (eventType === "play" && this._deps.isSkipRepeatsEnabled()) {
+				this._state.lastRecordedUri = this._state.capturedData.trackUri;
 			}
-		} catch (err) {
-			// Log warning but do NOT crash the FSM
-			console.warn("[listening-stats] Failed to write play event:", err);
+			// Notify listeners (play vs skip)
+			const eventName = eventType === "play" ? EVENTS.PLAY_RECORDED : EVENTS.SKIP_RECORDED;
+			this._deps.dispatchEvent(new CustomEvent(eventName, { detail: event }));
+
+			if (localStorage.getItem(LS_KEYS.LOGGING) === "true") {
+				console.log(
+					`[listening-stats] ${eventType}: "${event.trackName}" by ${event.artistName} (${Math.round(event.playedMs / 1000)}s)`,
+				);
+			}
 		}
+		return id;
 	}
 }

--- a/src/extension/tracker/index.ts
+++ b/src/extension/tracker/index.ts
@@ -3,11 +3,11 @@ import { backupToIdb } from "../../shared/storage/backup";
 import { db, registerVersionChangeHandler } from "../../shared/storage/db";
 import { runStartupChecks } from "../../shared/storage/integrity";
 import { initDatabase } from "../../shared/storage/migration-manager";
-import { addPlayEvent } from "../../shared/storage/play-events";
+import { addPlayEvent, updatePlayEventPlaytime } from "../../shared/storage/play-events";
 import type { PlayEvent } from "../../shared/types/play-event";
 import { TrackingFSM } from "./fsm";
 import { HealthIndicator } from "./health";
-import { getPlayThreshold, isSkipRepeatsEnabled, isTrackingPaused } from "./settings";
+import { isSkipRepeatsEnabled, isTrackingPaused, resolveThresholdMs } from "./settings";
 import { Watchdog } from "./watchdog";
 
 // ─── Module-level state ───────────────────────────────────────────────────────
@@ -53,14 +53,14 @@ export async function initTracker(): Promise<void> {
 	}
 
 	// Wrap addPlayEvent to feed health indicator on success/failure
-	const wrappedAddPlayEvent = async (event: PlayEvent): Promise<boolean> => {
+	const wrappedAddPlayEvent = async (event: PlayEvent): Promise<number | null> => {
 		try {
-			const written = await addPlayEvent(event);
-			if (written) {
+			const id = await addPlayEvent(event);
+			if (id !== null) {
 				health?.recordSuccess(event.trackName);
 				localStorage.setItem(LS_KEYS.LAST_WRITE, String(Date.now()));
 			}
-			return written;
+			return id;
 		} catch (err) {
 			health?.recordFailure(err instanceof Error ? err.message : String(err));
 			throw err;
@@ -69,7 +69,8 @@ export async function initTracker(): Promise<void> {
 
 	fsm = new TrackingFSM({
 		addPlayEvent: wrappedAddPlayEvent,
-		getPlayThreshold,
+		updatePlayEvent: updatePlayEventPlaytime,
+		resolveThresholdMs,
 		isTrackingPaused,
 		isSkipRepeatsEnabled,
 		dispatchEvent: (event: Event) => window.dispatchEvent(event),

--- a/src/extension/tracker/settings.ts
+++ b/src/extension/tracker/settings.ts
@@ -1,6 +1,9 @@
 import { LS_KEYS } from "../../shared/constants/storage-keys";
 
 export const DEFAULT_THRESHOLD_MS = 30_000; // default 30s play threshold (v1 used 10s)
+export const DEFAULT_THRESHOLD_PERCENT = 25;
+
+export type ThresholdMode = "seconds" | "percent";
 
 /**
  * Returns the configured play threshold in milliseconds.
@@ -23,15 +26,82 @@ export function getPlayThreshold(): number {
 
 /**
  * Sets the play threshold in milliseconds.
- * Clamps value to 0-60000 range.
+ * Clamps to 0-60000 and rounds to whole seconds.
  */
 export function setPlayThreshold(ms: number): void {
 	try {
-		const clamped = Math.max(0, Math.min(60000, ms));
+		const clamped = Math.max(0, Math.min(60000, Math.round(ms / 1000) * 1000));
 		localStorage.setItem(LS_KEYS.PLAY_THRESHOLD, String(clamped));
 	} catch {
 		// localStorage unavailable  -  silently ignore
 	}
+}
+
+/**
+ * Returns the play threshold as a percentage of track length (0-100 whole
+ * percent), used when the threshold mode is "percent".
+ */
+export function getPlayThresholdPercent(): number {
+	try {
+		const stored = localStorage.getItem(LS_KEYS.PLAY_THRESHOLD_PERCENT);
+		if (stored !== null) {
+			const val = parseInt(stored, 10);
+			if (!Number.isNaN(val) && val >= 0 && val <= 100) {
+				return val;
+			}
+		}
+	} catch {
+		// localStorage unavailable  -  return default
+	}
+	return DEFAULT_THRESHOLD_PERCENT;
+}
+
+/**
+ * Sets the percent play threshold. Clamps to 0-100 and rounds to whole percent.
+ */
+export function setPlayThresholdPercent(percent: number): void {
+	try {
+		const clamped = Math.max(0, Math.min(100, Math.round(percent)));
+		localStorage.setItem(LS_KEYS.PLAY_THRESHOLD_PERCENT, String(clamped));
+	} catch {
+		// localStorage unavailable  -  silently ignore
+	}
+}
+
+/**
+ * Returns the threshold mode: absolute seconds or percentage of track length.
+ */
+export function getThresholdMode(): ThresholdMode {
+	try {
+		return localStorage.getItem(LS_KEYS.PLAY_THRESHOLD_MODE) === "percent" ? "percent" : "seconds";
+	} catch {
+		return "seconds";
+	}
+}
+
+export function setThresholdMode(mode: ThresholdMode): void {
+	try {
+		if (mode === "percent") {
+			localStorage.setItem(LS_KEYS.PLAY_THRESHOLD_MODE, "percent");
+		} else {
+			localStorage.removeItem(LS_KEYS.PLAY_THRESHOLD_MODE);
+		}
+	} catch {
+		// localStorage unavailable  -  silently ignore
+	}
+}
+
+/**
+ * Resolves the effective play threshold in milliseconds for a track.
+ * Percent mode needs the track duration; with an unknown duration the
+ * threshold is unreachable (Infinity) and classification falls back to skip.
+ */
+export function resolveThresholdMs(durationMs: number): number {
+	if (getThresholdMode() === "percent") {
+		if (durationMs <= 0) return Number.POSITIVE_INFINITY;
+		return Math.round((durationMs * getPlayThresholdPercent()) / 100);
+	}
+	return getPlayThreshold();
 }
 
 /**

--- a/src/shared/constants/storage-keys.ts
+++ b/src/shared/constants/storage-keys.ts
@@ -1,5 +1,7 @@
 export const LS_KEYS = {
 	PLAY_THRESHOLD: "listening-stats:playThreshold",
+	PLAY_THRESHOLD_MODE: "listening-stats:playThresholdMode",
+	PLAY_THRESHOLD_PERCENT: "listening-stats:playThresholdPercent",
 	TRACKING_PAUSED: "listening-stats:tracking-paused",
 	SKIP_REPEATS: "listening-stats:skip-repeats",
 	LAST_UPDATE: "listening-stats:lastUpdate",

--- a/src/shared/storage/play-events.ts
+++ b/src/shared/storage/play-events.ts
@@ -4,8 +4,9 @@ import { db } from "./db";
 /**
  * Insert play event with 3s time-bucket dedup (same trackUri in bucket → skip).
  * Buckets use event.startedAt, not wall clock.
+ * Returns the new event id, or null when deduped.
  */
-export async function addPlayEvent(event: PlayEvent): Promise<boolean> {
+export async function addPlayEvent(event: PlayEvent): Promise<number | null> {
 	const bucketStart = Math.floor(event.startedAt / 3000) * 3000;
 	const bucketEnd = bucketStart + 3000;
 
@@ -19,10 +20,17 @@ export async function addPlayEvent(event: PlayEvent): Promise<boolean> {
 			.count();
 
 		if (existingCount > 0) {
-			return false;
+			return null;
 		}
 
-		await db.playEvents.add(event);
-		return true;
+		return (await db.playEvents.add(event)) ?? null;
 	});
+}
+
+/**
+ * Updates the final play time of an event that was written the moment it
+ * crossed the play threshold (the track kept playing after the write).
+ */
+export async function updatePlayEventPlaytime(id: number, playedMs: number, endedAt: number): Promise<void> {
+	await db.playEvents.update(id, { playedMs, endedAt });
 }

--- a/src/test/dedup.test.ts
+++ b/src/test/dedup.test.ts
@@ -26,25 +26,25 @@ describe("addPlayEvent dedup", () => {
 		await db.open();
 	});
 
-	it("adds event and returns true", async () => {
+	it("adds event and returns the new id", async () => {
 		const event = makeEvent("spotify:track:abc", 10000);
 		const result = await addPlayEvent(event);
-		expect(result).toBe(true);
+		expect(result).toEqual(expect.any(Number));
 		const count = await db.playEvents.count();
 		expect(count).toBe(1);
 	});
 
-	it("returns false when same trackUri and startedAt in same 3-second bucket", async () => {
+	it("returns null when same trackUri and startedAt in same 3-second bucket", async () => {
 		const startedAt = 10000;
 		const event1 = makeEvent("spotify:track:abc", startedAt);
 		// startedAt2 = 11000, bucket = floor(11000/3000)*3000 = 9000, same as floor(10000/3000)*3000 = 9000
 		const event2 = makeEvent("spotify:track:abc", 11000);
 
 		const result1 = await addPlayEvent(event1);
-		expect(result1).toBe(true);
+		expect(result1).toEqual(expect.any(Number));
 
 		const result2 = await addPlayEvent(event2);
-		expect(result2).toBe(false);
+		expect(result2).toBeNull();
 	});
 
 	it("allows same trackUri in different 3-second bucket", async () => {
@@ -54,10 +54,10 @@ describe("addPlayEvent dedup", () => {
 		const event2 = makeEvent("spotify:track:abc", 13000);
 
 		const result1 = await addPlayEvent(event1);
-		expect(result1).toBe(true);
+		expect(result1).toEqual(expect.any(Number));
 
 		const result2 = await addPlayEvent(event2);
-		expect(result2).toBe(true);
+		expect(result2).toEqual(expect.any(Number));
 	});
 
 	it("allows different trackUri in same 3-second bucket", async () => {
@@ -66,10 +66,10 @@ describe("addPlayEvent dedup", () => {
 		const event2 = makeEvent("spotify:track:xyz", 11000);
 
 		const result1 = await addPlayEvent(event1);
-		expect(result1).toBe(true);
+		expect(result1).toEqual(expect.any(Number));
 
 		const result2 = await addPlayEvent(event2);
-		expect(result2).toBe(true);
+		expect(result2).toEqual(expect.any(Number));
 	});
 
 	it("does not store duplicate when dedup blocks", async () => {

--- a/src/test/local-files-dj.test.ts
+++ b/src/test/local-files-dj.test.ts
@@ -37,8 +37,9 @@ function makePlayEvent(overrides: Partial<PlayEvent> = {}): PlayEvent {
 
 function makeDeps(overrides: Partial<TrackingFSMDeps> = {}): TrackingFSMDeps {
 	return {
-		addPlayEvent: vi.fn(() => Promise.resolve(true)),
-		getPlayThreshold: vi.fn(() => 30000),
+		addPlayEvent: vi.fn(() => Promise.resolve(1)),
+		updatePlayEvent: vi.fn(() => Promise.resolve()),
+		resolveThresholdMs: vi.fn(() => 30000),
 		isTrackingPaused: vi.fn(() => false),
 		isSkipRepeatsEnabled: vi.fn(() => false),
 		dispatchEvent: vi.fn(),

--- a/src/test/settings.test.ts
+++ b/src/test/settings.test.ts
@@ -1,10 +1,15 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import {
 	getPlayThreshold,
+	getPlayThresholdPercent,
+	getThresholdMode,
 	isSkipRepeatsEnabled,
 	isTrackingPaused,
+	resolveThresholdMs,
 	setPlayThreshold,
+	setPlayThresholdPercent,
 	setSkipRepeatsEnabled,
+	setThresholdMode,
 	setTrackingPaused,
 } from "../extension/tracker/settings";
 import { LS_KEYS } from "../shared/constants/storage-keys";
@@ -63,6 +68,80 @@ describe("Settings accessors", () => {
 		it("clamps value to 60000 maximum", () => {
 			setPlayThreshold(99999);
 			expect(localStorage.getItem(LS_KEYS.PLAY_THRESHOLD)).toBe("60000");
+		});
+
+		it("rounds to whole seconds", () => {
+			setPlayThreshold(12222);
+			expect(localStorage.getItem(LS_KEYS.PLAY_THRESHOLD)).toBe("12000");
+			setPlayThreshold(12600);
+			expect(localStorage.getItem(LS_KEYS.PLAY_THRESHOLD)).toBe("13000");
+		});
+	});
+
+	describe("threshold mode", () => {
+		it("defaults to seconds", () => {
+			expect(getThresholdMode()).toBe("seconds");
+		});
+
+		it("persists percent mode", () => {
+			setThresholdMode("percent");
+			expect(getThresholdMode()).toBe("percent");
+		});
+
+		it("clears the key when set back to seconds", () => {
+			setThresholdMode("percent");
+			setThresholdMode("seconds");
+			expect(localStorage.getItem(LS_KEYS.PLAY_THRESHOLD_MODE)).toBeNull();
+			expect(getThresholdMode()).toBe("seconds");
+		});
+	});
+
+	describe("percent threshold", () => {
+		it("defaults to 25", () => {
+			expect(getPlayThresholdPercent()).toBe(25);
+		});
+
+		it("returns stored value when valid", () => {
+			setPlayThresholdPercent(10);
+			expect(getPlayThresholdPercent()).toBe(10);
+		});
+
+		it("clamps to 0-100 and rounds to whole percent", () => {
+			setPlayThresholdPercent(150);
+			expect(getPlayThresholdPercent()).toBe(100);
+			setPlayThresholdPercent(-5);
+			expect(getPlayThresholdPercent()).toBe(0);
+			setPlayThresholdPercent(12.7);
+			expect(getPlayThresholdPercent()).toBe(13);
+		});
+
+		it("falls back to default for out-of-range stored values", () => {
+			localStorage.setItem(LS_KEYS.PLAY_THRESHOLD_PERCENT, "999");
+			expect(getPlayThresholdPercent()).toBe(25);
+		});
+	});
+
+	describe("resolveThresholdMs", () => {
+		it("returns the ms threshold in seconds mode", () => {
+			setPlayThreshold(12000);
+			expect(resolveThresholdMs(200000)).toBe(12000);
+		});
+
+		it("ignores duration in seconds mode", () => {
+			setPlayThreshold(12000);
+			expect(resolveThresholdMs(0)).toBe(12000);
+		});
+
+		it("returns percent of duration in percent mode", () => {
+			setThresholdMode("percent");
+			setPlayThresholdPercent(10);
+			expect(resolveThresholdMs(200000)).toBe(20000);
+		});
+
+		it("is unreachable in percent mode when duration is unknown", () => {
+			setThresholdMode("percent");
+			setPlayThresholdPercent(10);
+			expect(resolveThresholdMs(0)).toBe(Number.POSITIVE_INFINITY);
 		});
 	});
 

--- a/src/test/threshold-slider.test.ts
+++ b/src/test/threshold-slider.test.ts
@@ -1,0 +1,112 @@
+import { cleanup, fireEvent, render } from "@testing-library/react";
+import React from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+afterEach(() => {
+	cleanup();
+});
+
+const defaultProps = {
+	max: 60,
+	value: 30,
+	presets: [0, 15, 30, 45, 60],
+	onChange: vi.fn(),
+	formatValue: (v: number) => `${v}s`,
+};
+
+async function renderSlider(overrides: Partial<typeof defaultProps> = {}) {
+	const { ThresholdSlider } = await import("../app/components/ThresholdSlider");
+	const props = { ...defaultProps, onChange: vi.fn(), ...overrides };
+	const result = render(React.createElement(ThresholdSlider, props));
+	return { ...result, props };
+}
+
+describe("ThresholdSlider", () => {
+	it("renders the handle with the formatted value", async () => {
+		const { container } = await renderSlider({ value: 12 });
+		const handle = container.querySelector(".threshold-slider-handle");
+		expect(handle?.textContent).toBe("12s");
+	});
+
+	it("positions the handle proportionally to the value", async () => {
+		const { container } = await renderSlider({ value: 30, max: 60 });
+		const handle = container.querySelector(".threshold-slider-handle") as HTMLElement;
+		expect(handle.style.left).toBe("50%");
+	});
+
+	it("renders one clickable label per preset", async () => {
+		const { container } = await renderSlider();
+		const presets = container.querySelectorAll(".threshold-slider-preset");
+		expect(presets).toHaveLength(5);
+		expect(presets[1].textContent).toBe("15s");
+	});
+
+	it("snaps to a preset when its label is clicked", async () => {
+		const { container, props } = await renderSlider({ value: 12 });
+		const presets = container.querySelectorAll(".threshold-slider-preset");
+		fireEvent.click(presets[3]); // 45
+		expect(props.onChange).toHaveBeenCalledWith(45);
+	});
+
+	it("marks the matching preset as active", async () => {
+		const { container } = await renderSlider({ value: 45 });
+		const active = container.querySelectorAll(".threshold-slider-preset.active");
+		expect(active).toHaveLength(1);
+		expect(active[0].textContent).toBe("45s");
+	});
+
+	it("sets a whole-unit value when the rail is clicked", async () => {
+		const { container, props } = await renderSlider({ value: 0, max: 60 });
+		const rail = container.querySelector(".threshold-slider-rail") as HTMLElement;
+		vi.spyOn(rail, "getBoundingClientRect").mockReturnValue({
+			left: 0,
+			width: 300,
+			top: 0,
+			right: 300,
+			bottom: 28,
+			height: 28,
+			x: 0,
+			y: 0,
+			toJSON: () => ({}),
+		} as DOMRect);
+		// 61px of 300px * 60 = 12.2 → rounds to whole 12
+		fireEvent.pointerDown(rail, { clientX: 61, pointerId: 1 });
+		expect(props.onChange).toHaveBeenCalledWith(12);
+	});
+
+	it("clamps rail clicks to the 0..max range", async () => {
+		const { container, props } = await renderSlider({ value: 30, max: 60 });
+		const rail = container.querySelector(".threshold-slider-rail") as HTMLElement;
+		vi.spyOn(rail, "getBoundingClientRect").mockReturnValue({
+			left: 0,
+			width: 300,
+			top: 0,
+			right: 300,
+			bottom: 28,
+			height: 28,
+			x: 0,
+			y: 0,
+			toJSON: () => ({}),
+		} as DOMRect);
+		fireEvent.pointerDown(rail, { clientX: 9999, pointerId: 1 });
+		expect(props.onChange).toHaveBeenCalledWith(60);
+		fireEvent.pointerDown(rail, { clientX: -50, pointerId: 1 });
+		expect(props.onChange).toHaveBeenCalledWith(0);
+	});
+
+	it("steps by one whole unit with arrow keys", async () => {
+		const { container, props } = await renderSlider({ value: 30 });
+		const handle = container.querySelector(".threshold-slider-handle") as HTMLElement;
+		fireEvent.keyDown(handle, { key: "ArrowRight" });
+		expect(props.onChange).toHaveBeenCalledWith(31);
+		fireEvent.keyDown(handle, { key: "ArrowLeft" });
+		expect(props.onChange).toHaveBeenCalledWith(29);
+	});
+
+	it("does not step past the range edges", async () => {
+		const { container, props } = await renderSlider({ value: 60, max: 60 });
+		const handle = container.querySelector(".threshold-slider-handle") as HTMLElement;
+		fireEvent.keyDown(handle, { key: "ArrowUp" });
+		expect(props.onChange).toHaveBeenCalledWith(60);
+	});
+});

--- a/src/test/tracker-fsm.test.ts
+++ b/src/test/tracker-fsm.test.ts
@@ -35,8 +35,9 @@ function makePlayerData(
 
 function makeDeps(overrides: Partial<TrackingFSMDeps> = {}): TrackingFSMDeps {
 	return {
-		addPlayEvent: vi.fn(() => Promise.resolve(true)),
-		getPlayThreshold: vi.fn(() => 30000),
+		addPlayEvent: vi.fn(() => Promise.resolve(1)),
+		updatePlayEvent: vi.fn(() => Promise.resolve()),
+		resolveThresholdMs: vi.fn(() => 30000),
 		isTrackingPaused: vi.fn(() => false),
 		isSkipRepeatsEnabled: vi.fn(() => false),
 		dispatchEvent: vi.fn(),
@@ -168,7 +169,7 @@ describe("TrackingFSM", () => {
 				...deps,
 				addPlayEvent: vi.fn(async (event) => {
 					expect(event.type).toBe("play");
-					return true;
+					return 1;
 				}),
 			});
 			// Start tracking track A
@@ -190,9 +191,9 @@ describe("TrackingFSM", () => {
 				...makeDeps(),
 				addPlayEvent: vi.fn(async (event) => {
 					capturedType = event.type;
-					return true;
+					return 1;
 				}),
-				getPlayThreshold: vi.fn(() => 30000),
+				resolveThresholdMs: vi.fn(() => 30000),
 			});
 			// Start tracking with durationMs = 180000 (> threshold)
 			await fsmSkip.handleSongChange(makePlayerData({ uri: "spotify:track:A", durationMs: 180000 }));
@@ -209,9 +210,9 @@ describe("TrackingFSM", () => {
 				...makeDeps(),
 				addPlayEvent: vi.fn(async (event) => {
 					capturedType = event.type;
-					return true;
+					return 1;
 				}),
-				getPlayThreshold: vi.fn(() => 30000),
+				resolveThresholdMs: vi.fn(() => 30000),
 			});
 			await fsmShort.handleSongChange(makePlayerData({ uri: "spotify:track:A", durationMs: 5000 }));
 			await fsmShort.handleSongChange(makePlayerData({ uri: "spotify:track:B", durationMs: 5000 }));
@@ -224,9 +225,9 @@ describe("TrackingFSM", () => {
 				...makeDeps(),
 				addPlayEvent: vi.fn(async (event) => {
 					capturedType = event.type;
-					return true;
+					return 1;
 				}),
-				getPlayThreshold: vi.fn(() => 30000),
+				resolveThresholdMs: vi.fn(() => 30000),
 			});
 			await fsmShort.handleSongChange(makePlayerData({ uri: "spotify:track:A", durationMs: 5000 }));
 			const spy = vi.spyOn(Date, "now").mockReturnValue(Date.now() + 4600);
@@ -302,7 +303,7 @@ describe("TrackingFSM", () => {
 		it("suppresses consecutive plays of same trackUri when skip-repeats enabled", async () => {
 			const skipDeps = makeDeps({
 				isSkipRepeatsEnabled: vi.fn(() => true),
-				addPlayEvent: vi.fn(async () => true),
+				addPlayEvent: vi.fn(async () => 1),
 			});
 			const skipFsm = new TrackingFSM(skipDeps);
 
@@ -350,6 +351,91 @@ describe("TrackingFSM", () => {
 			expect(deps.dispatchEvent).toHaveBeenCalledTimes(1);
 			const eventArg = (deps.dispatchEvent as ReturnType<typeof vi.fn>).mock.calls[0][0];
 			expect(eventArg.type).toBe("listening-stats:skip-recorded");
+		});
+	});
+
+	describe("threshold-cross immediate recording", () => {
+		const flush = () => new Promise((r) => setTimeout(r, 0));
+
+		it("records the play the moment the threshold is crossed, without a song change", async () => {
+			await fsm.handleSongChange(makePlayerData({ uri: "spotify:track:A", durationMs: 180000 }));
+			const spy = vi.spyOn(Date, "now").mockReturnValue(Date.now() + 35000);
+			fsm.handlePlayPause(true); // bank 35s > 30s threshold
+			spy.mockRestore();
+			await flush();
+
+			expect(deps.addPlayEvent).toHaveBeenCalledTimes(1);
+			const event = (deps.addPlayEvent as ReturnType<typeof vi.fn>).mock.calls[0][0];
+			expect(event.trackUri).toBe("spotify:track:A");
+			expect(event.type).toBe("play");
+			const snap = fsm.getSnapshot();
+			expect(snap.recordedEventId).toBe(1);
+		});
+
+		it("records instantly at song start when the threshold is 0", async () => {
+			const zeroFsm = new TrackingFSM({ ...deps, resolveThresholdMs: vi.fn(() => 0) });
+			await zeroFsm.handleSongChange(makePlayerData({ uri: "spotify:track:A", durationMs: 180000 }));
+			expect(deps.addPlayEvent).toHaveBeenCalledTimes(1);
+			expect((deps.addPlayEvent as ReturnType<typeof vi.fn>).mock.calls[0][0].type).toBe("play");
+		});
+
+		it("records via progress ticks while the track keeps playing", async () => {
+			await fsm.handleSongChange(makePlayerData({ uri: "spotify:track:A", durationMs: 180000 }));
+			const start = Date.now();
+			const spy = vi.spyOn(Date, "now").mockReturnValue(start + 40000);
+			fsm.handleProgress(40000, 180000, 0);
+			spy.mockRestore();
+			await flush();
+			expect(deps.addPlayEvent).toHaveBeenCalledTimes(1);
+			expect((deps.addPlayEvent as ReturnType<typeof vi.fn>).mock.calls[0][0].type).toBe("play");
+		});
+
+		it("does not record twice: song end patches the recorded event instead", async () => {
+			await fsm.handleSongChange(makePlayerData({ uri: "spotify:track:A", durationMs: 180000 }));
+			const spy = vi.spyOn(Date, "now").mockReturnValue(Date.now() + 35000);
+			fsm.handlePlayPause(true);
+			spy.mockRestore();
+			await flush();
+
+			await fsm.handleSongChange(makePlayerData({ uri: "spotify:track:B", durationMs: 180000 }));
+			expect(deps.addPlayEvent).toHaveBeenCalledTimes(1);
+			expect(deps.updatePlayEvent).toHaveBeenCalledTimes(1);
+			const [id, playedMs] = (deps.updatePlayEvent as ReturnType<typeof vi.fn>).mock.calls[0];
+			expect(id).toBe(1);
+			expect(playedMs).toBeGreaterThanOrEqual(35000);
+		});
+
+		it("records at the percent threshold when the resolver derives it from duration", async () => {
+			const pctFsm = new TrackingFSM({
+				...deps,
+				resolveThresholdMs: vi.fn((durationMs: number) => durationMs * 0.1),
+			});
+			await pctFsm.handleSongChange(makePlayerData({ uri: "spotify:track:A", durationMs: 200000 }));
+			const spy = vi.spyOn(Date, "now").mockReturnValue(Date.now() + 25000);
+			pctFsm.handlePlayPause(true); // 25s > 10% of 200s (20s)
+			spy.mockRestore();
+			await flush();
+			expect(deps.addPlayEvent).toHaveBeenCalledTimes(1);
+		});
+
+		it("does not record below the threshold", async () => {
+			await fsm.handleSongChange(makePlayerData({ uri: "spotify:track:A", durationMs: 180000 }));
+			const spy = vi.spyOn(Date, "now").mockReturnValue(Date.now() + 10000);
+			fsm.handlePlayPause(true);
+			spy.mockRestore();
+			await flush();
+			expect(deps.addPlayEvent).not.toHaveBeenCalled();
+		});
+
+		it("does not record on cross when tracking is paused", async () => {
+			const pausedDeps = makeDeps({ isTrackingPaused: vi.fn(() => true) });
+			const pausedFsm = new TrackingFSM(pausedDeps);
+			await pausedFsm.handleSongChange(makePlayerData({ uri: "spotify:track:A", durationMs: 180000 }));
+			const spy = vi.spyOn(Date, "now").mockReturnValue(Date.now() + 35000);
+			pausedFsm.handlePlayPause(true);
+			spy.mockRestore();
+			await flush();
+			expect(pausedDeps.addPlayEvent).not.toHaveBeenCalled();
 		});
 	});
 

--- a/src/test/tracker-init.test.ts
+++ b/src/test/tracker-init.test.ts
@@ -196,20 +196,22 @@ describe("tracker/index  -  initTracker()", () => {
 		expect(typeof originalSongHandler).toBe("function");
 	});
 
-	it("when wrapped addPlayEvent resolves true, health.recordSuccess is called with track name", async () => {
+	it("when wrapped addPlayEvent resolves an id, health.recordSuccess is called with track name", async () => {
 		const stub = makeSpicetifyStub();
 		(globalThis as unknown as Record<string, unknown>).Spicetify = stub;
 
 		// Mock addPlayEvent to resolve true
-		const mockAddPlayEvent = vi.fn().mockResolvedValue(true);
+		const mockAddPlayEvent = vi.fn().mockResolvedValue(1);
 		vi.doMock("../shared/storage/play-events", () => ({
 			addPlayEvent: mockAddPlayEvent,
+			updatePlayEventPlaytime: vi.fn().mockResolvedValue(undefined),
 		}));
 
 		vi.resetModules();
 		// Re-mock after resetModules
 		vi.doMock("../shared/storage/play-events", () => ({
 			addPlayEvent: mockAddPlayEvent,
+			updatePlayEventPlaytime: vi.fn().mockResolvedValue(undefined),
 		}));
 
 		const { initTracker } = await import("../extension/tracker/index");
@@ -269,6 +271,7 @@ describe("tracker/index  -  initTracker()", () => {
 		const mockAddPlayEvent = vi.fn().mockRejectedValue(new Error("DB write failed"));
 		vi.doMock("../shared/storage/play-events", () => ({
 			addPlayEvent: mockAddPlayEvent,
+			updatePlayEventPlaytime: vi.fn().mockResolvedValue(undefined),
 		}));
 
 		const stub = makeSpicetifyStub();
@@ -343,10 +346,11 @@ describe("tracker/index  -  health recording", () => {
 		delete (window as unknown as Record<string, unknown>).__lsProgressHandler;
 	});
 
-	it("recordSuccess called with trackName when addPlayEvent resolves true", async () => {
-		const mockAddPlayEvent = vi.fn().mockResolvedValue(true);
+	it("recordSuccess called with trackName when addPlayEvent resolves an id", async () => {
+		const mockAddPlayEvent = vi.fn().mockResolvedValue(1);
 		vi.doMock("../shared/storage/play-events", () => ({
 			addPlayEvent: mockAddPlayEvent,
+			updatePlayEventPlaytime: vi.fn().mockResolvedValue(undefined),
 		}));
 
 		const { HealthIndicator } = await import("../extension/tracker/health");
@@ -407,6 +411,7 @@ describe("tracker/index  -  health recording", () => {
 		const mockAddPlayEvent = vi.fn().mockRejectedValue(testError);
 		vi.doMock("../shared/storage/play-events", () => ({
 			addPlayEvent: mockAddPlayEvent,
+			updatePlayEventPlaytime: vi.fn().mockResolvedValue(undefined),
 		}));
 
 		const { HealthIndicator } = await import("../extension/tracker/health");
@@ -568,9 +573,10 @@ describe("tracker/index integrity and versionchange wiring", () => {
 	});
 
 	it("wrappedAddPlayEvent sets LAST_WRITE in localStorage on successful write", async () => {
-		const mockAddPlayEvent = vi.fn().mockResolvedValue(true);
+		const mockAddPlayEvent = vi.fn().mockResolvedValue(1);
 		vi.doMock("../shared/storage/play-events", () => ({
 			addPlayEvent: mockAddPlayEvent,
+			updatePlayEventPlaytime: vi.fn().mockResolvedValue(undefined),
 		}));
 		vi.doMock("../shared/storage/integrity", () => ({
 			runStartupChecks: vi.fn().mockResolvedValue({

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,6 +2,7 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
 	test: {
+		include: ["src/**/*.test.{ts,tsx}"],
 		environment: "jsdom",
 		globals: true,
 		setupFiles: ["./src/test/setup.ts"],


### PR DESCRIPTION
## Description

<!-- What does this PR do? Briefly describe the change. -->

## Type of Change

<!-- Check the relevant option(s). -->

- [ ] Bug fix
- [ ] New feature
- [ ] Enhancement / improvement
- [ ] Documentation
- [ ] Refactor (no functional change)
- [ ] Other (describe below)

## Related Issue

<!-- Link any related issues. Use "Fixes #123" to auto-close. -->

## How to Test

<!-- Steps to test your changes locally. -->

1. `npm install && npm run build`
2. Deploy to Spicetify: `npm run deploy`
3. Open Listening Stats in Spotify sidebar
4. ...

## Checklist

- [ ] Tested locally with `npm run build` (no errors)
- [ ] Tested in Spotify with Spicetify applied
- [ ] Changes work with all providers (Local / stats.fm / Last.fm) if applicable
- [ ] No sensitive data (API keys, tokens) included in the code

## Screenshots

<!-- If applicable, add screenshots showing the change. -->
