### PR TITLE
Fix Windows installer temporary cleanup

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -152,6 +152,28 @@ function Test-PathSafe {
     catch { return $false }
 }
 
+function Remove-TemporaryPath {
+    # Temporary cleanup must never turn an otherwise successful install into a failure.
+    # Use LiteralPath so usernames or temp directories containing wildcard characters are
+    # handled as exact paths, and tolerate stale/invalid short-path aliases reported by some
+    # Windows PowerShell environments.
+    param([string]$Path, [switch]$Recurse)
+    if (-not (Test-PathSafe $Path)) { return }
+
+    try {
+        $params = @{
+            LiteralPath = $Path
+            Force       = $true
+            ErrorAction = 'Stop'
+        }
+        if ($Recurse) { $params.Recurse = $true }
+        Remove-Item @params
+    }
+    catch {
+        Warn "could not remove temporary path at $Path  -  $($_.Exception.Message)"
+    }
+}
+
 function Get-SpicetifyPath {
     param([Parameter(Mandatory)][string[]]$ArgumentList)
     $res = Invoke-Spicetify -ArgumentList $ArgumentList
@@ -285,7 +307,7 @@ function Ensure-SpicetifyCli {
         Expand-Archive -Path $spTmpZip -DestinationPath $spicetifyDir -Force
     }
     finally {
-        Remove-Item -Force $spTmpZip -ErrorAction SilentlyContinue
+        Remove-TemporaryPath -Path $spTmpZip
     }
 
     $userScope = [EnvironmentVariableTarget]::User
@@ -445,8 +467,8 @@ try {
     Confirm-NoNestedAppLayout -AppDir $Dest
 }
 finally {
-    Remove-Item -Force $TmpZip -ErrorAction SilentlyContinue
-    Remove-Item -Recurse -Force $ExtractRoot -ErrorAction SilentlyContinue
+    Remove-TemporaryPath -Path $TmpZip
+    Remove-TemporaryPath -Path $ExtractRoot -Recurse
 }
 
 Invoke-SpicetifyApplyWithRecovery


### PR DESCRIPTION
## Description

Prevents Windows installer temporary-file cleanup from failing an otherwise successful installation.

- Adds one best-effort cleanup helper that uses `-LiteralPath` for exact path handling.
- Skips missing or invalid paths safely.
- Converts cleanup failures into warnings instead of terminating the installer.
- Uses the helper for the Spicetify bootstrap archive and the Listening Stats archive/extraction directory.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Enhancement / improvement
- [ ] Documentation
- [ ] Refactor (no functional change)
- [ ] Other

## Related Issue

Fixes #55

## How to Test

1. Parse `install.ps1` with Windows PowerShell 5.1.
2. Invoke the cleanup helper with file and directory paths containing spaces and `[]` wildcard characters.
3. Verify both paths are removed and a missing path does not throw.
4. Run the repository checks listed below.

## Verification

- Windows PowerShell 5.1 parser and focused cleanup regression: passed.
- `corepack pnpm@9.15.9 lint`: passed with three pre-existing CSS specificity warnings.
- `corepack pnpm@9.15.9 typecheck`: passed.
- `TZ=UTC corepack pnpm@9.15.9 exec vitest run --reporter=dot`: 79 test files and 1,222 tests passed.
- `NODE_ENV=production corepack pnpm@9.15.9 build`: passed.
- `git diff --check`: passed.

## Checklist

- [x] Tested locally with a production build (no errors)
- [ ] Tested by reinstalling into Spotify/Spicetify (not run because this cleanup-only patch would mutate the local application installation)
- [x] Provider behavior is unaffected
- [x] No sensitive data included
