### PR TITLE
fix: show lifetime last.fm play count on playbar (closes #66)

### DIFF
--- a/src/app/components/PlaybarWidget.tsx
+++ b/src/app/components/PlaybarWidget.tsx
@@ -1,3 +1,4 @@
+import { fetchLastfmLifetimeTrackPlaycount, readLastfmUsername } from "../../shared/api/lastfm-track-plays";
 import {
 	fetchStatsFmLifetimeTrackStreams,
 	fetchStatsFmPeriodTrackStreams,
@@ -62,6 +63,23 @@ function useNowPlayingCount(): TrackPlayInfo | null {
 					const firstPlayedAt = lifetime != null ? null : localFirst;
 					commit({ count, firstPlayedAt, periodStreams, periodLabel });
 					return;
+				}
+			}
+
+			if (providerRegistry.getActiveId() === "lastfm") {
+				const username = readLastfmUsername();
+				if (username) {
+					const item = Spicetify.Player.data?.item;
+					const trackName = item?.name as string | undefined;
+					const metadata = item?.metadata as Record<string, unknown> | undefined;
+					const artistName = metadata?.artist_name as string | undefined;
+					if (trackName && artistName) {
+						const lifetime = await fetchLastfmLifetimeTrackPlaycount(artistName, trackName);
+						const count = lifetime ?? localCount;
+						const firstPlayedAt = lifetime != null ? null : localFirst;
+						commit({ count, firstPlayedAt, periodStreams: null, periodLabel: null });
+						return;
+					}
 				}
 			}
 

--- a/src/shared/api/lastfm-client.ts
+++ b/src/shared/api/lastfm-client.ts
@@ -252,3 +252,27 @@ export async function lastfmGetTopAlbums(
 		imageUrl: bestImage(a.image),
 	}));
 }
+
+interface LfmTrackInfoRaw {
+	track?: { userplaycount?: string };
+}
+
+export async function lastfmGetTrackUserPlaycount(
+	apiKey: string,
+	username: string,
+	artist: string,
+	track: string,
+): Promise<number | null> {
+	try {
+		const data = await lastfmUserFetch<LfmTrackInfoRaw>(apiKey, "track.getInfo", {
+			artist,
+			track,
+			username,
+			autocorrect: "1",
+		});
+		const raw = data.track?.userplaycount;
+		return raw !== undefined ? parseInt(raw, 10) || 0 : null;
+	} catch {
+		return null;
+	}
+}

--- a/src/shared/api/lastfm-track-plays.ts
+++ b/src/shared/api/lastfm-track-plays.ts
@@ -1,0 +1,30 @@
+import { LS_KEYS } from "../constants/storage-keys";
+import { lastfmGetTrackUserPlaycount } from "./lastfm-client";
+
+interface LastfmConfig {
+	apiKey: string;
+	username: string;
+}
+
+function readLastfmConfig(): LastfmConfig | null {
+	try {
+		const raw = localStorage.getItem(LS_KEYS.LASTFM_CONFIG);
+		if (!raw) return null;
+		const parsed = JSON.parse(raw) as Partial<LastfmConfig>;
+		return typeof parsed.apiKey === "string" && typeof parsed.username === "string"
+			? { apiKey: parsed.apiKey, username: parsed.username }
+			: null;
+	} catch {
+		return null;
+	}
+}
+
+export function readLastfmUsername(): string | null {
+	return readLastfmConfig()?.username ?? null;
+}
+
+export async function fetchLastfmLifetimeTrackPlaycount(artist: string, track: string): Promise<number | null> {
+	const config = readLastfmConfig();
+	if (!config) return null;
+	return lastfmGetTrackUserPlaycount(config.apiKey, config.username, artist, track);
+}


### PR DESCRIPTION
## What
When the **Last.fm** provider is active, the now-playing pill on the playbar now shows the track's **lifetime play count** (the user's total scrobbles for that track) instead of only the locally-logged play count since app install.

## Why
Fixes #66 — for Last.fm users, the playbar always fell back to the local counter (plays since the custom app was installed), which is not what they expect to see.

## How
Mirrors the existing stats.fm handling:

- **`src/shared/api/lastfm-client.ts`** — new `lastfmGetTrackUserPlaycount()` that calls `track.getInfo` with the `username` parameter, which returns the `userplaycount` field directly (one request, no pagination).
- **`src/shared/api/lastfm-track-plays.ts`** (new) — reads the saved Last.fm config from localStorage and exposes `fetchLastfmLifetimeTrackPlaycount(artist, track)`, analogous to `statsfm-track-plays.ts`.
- **`src/app/components/PlaybarWidget.tsx`** — when the active provider is `lastfm`, look up the playing track's artist/name from `Spicetify.Player.data.item`, query the lifetime count, and fall back to the local count if the API returns nothing.

## Notes
- Artist/track come from `Spicetify.Player.data.item`, matching how the tracker already reads track metadata.
- Uses the same `commit`/generation-guard pattern as the stats.fm path, so a slow response can't overwrite a newer track's count.

No behavior change for the local or stats.fm providers.